### PR TITLE
Added function calls

### DIFF
--- a/include/Vandior/ExpressionFactory.hpp
+++ b/include/Vandior/ExpressionFactory.hpp
@@ -26,13 +26,15 @@ namespace vnd {
         std::shared_ptr<Scope> _scope;
         std::vector<std::string> _text;
         std::vector<Expression> _expressions;
-        char _lastOperator;
+        int _power;
+        bool _divide;
         [[nodiscard]] std::string_view getTokenType(const Token &token) const noexcept;
         void emplaceToken() noexcept;
         [[nodiscard]] std::string writeToken() noexcept;
         [[nodiscard]] std::string handleFun(TupType &type) noexcept;
         [[nodiscard]] std::string handleInnerExpression(TupType &type) noexcept;
         [[nodiscard]] std::string handleToken(TupType &type) noexcept;
+        void checkOperators(std::string &value) noexcept;
     };
 
 }  // namespace vnd

--- a/include/Vandior/ExpressionFactory.hpp
+++ b/include/Vandior/ExpressionFactory.hpp
@@ -11,16 +11,15 @@ namespace vnd {
     public:
         [[nodiscard]] static ExpressionFactory create(std::vector<Token>::iterator &iterator, std::vector<Token>::iterator end,
                                                       std::shared_ptr<Scope> scope) noexcept;
-        [[nodiscard]] static bool isNumber(const std::string &type) noexcept;
         [[nodiscard]] std::string parse(const std::vector<TokenType> &endToken) noexcept;
         [[nodiscard]] std::size_t size() const noexcept;
         [[nodiscard]] bool empty() const noexcept;
         [[nodiscard]] Expression getExpression() noexcept;
+        [[nodiscard]] std::vector<Expression> getExpressions() noexcept;
     private:
         ExpressionFactory(std::vector<Token>::iterator &iterator, std::vector<Token>::iterator end,
                           std::shared_ptr<Scope> scope) noexcept;
         using TupType = std::tuple<bool, bool, std::string>;
-        static std::vector<std::string> _numberTypes;
         [[nodiscard]] static std::string checkType(TupType &oldType, const std::string_view newType) noexcept;
         std::vector<Token>::iterator &_iterator;
         std::vector<Token>::iterator _end;
@@ -31,6 +30,7 @@ namespace vnd {
         [[nodiscard]] std::string_view getTokenType(const Token &token) const noexcept;
         void emplaceToken() noexcept;
         [[nodiscard]] std::string writeToken() noexcept;
+        [[nodiscard]] std::string handleFun(TupType &type) noexcept;
         [[nodiscard]] std::string handleInnerExpression(TupType &type) noexcept;
         [[nodiscard]] std::string handleToken(TupType &type) noexcept;
     };

--- a/include/Vandior/Scope.hpp
+++ b/include/Vandior/Scope.hpp
@@ -1,28 +1,38 @@
 #pragma once
+#include "Vandior/Expression.hpp"
 #include <iostream>
 #include <memory>
+#include <vector>
 #include <unordered_map>
 #include <unordered_set>
+#include <tuple>
 
 namespace vnd {
 
     class Scope {
     public:
+        using FunType = std::tuple<std::string, std::vector<std::string>>;
         [[nodiscard]] static std::shared_ptr<Scope> create(std::shared_ptr<Scope> parent) noexcept;
         [[nodiscard]] static std::shared_ptr<Scope> createMain() noexcept;
+        [[nodiscard]] static bool isNumber(const std::string &type) noexcept;
+        [[nodiscard]] static bool canAssign(const std::string &left, const std::string &right) noexcept;
         [[nodiscard]] std::shared_ptr<Scope> getParent() const noexcept;
         void removeParent() noexcept;
         void addType(const std::string_view type) noexcept;
         void addVariable(const std::string_view identifier, const std::string_view type, const bool isConst) noexcept;
+        void addFun(const std::string_view identifier, const FunType &fun) noexcept;
         [[nodiscard]] bool isMainScope() const noexcept;
         [[nodiscard]] bool checkType(const std::string_view type) const noexcept;
         [[nodiscard]] std::pair<bool, bool> checkVariable(const std::string_view identifier, const bool shadowing = false) const noexcept;
         [[nodiscard]] std::string_view getVariableType(const std::string_view identifier) const noexcept;
+        [[nodiscard]] std::string getFunType(const std::string_view identifier, const std::vector<Expression> &expressions) const noexcept;
     private:
         Scope(std::shared_ptr<Scope> parent) noexcept;
+        static std::vector<std::string> _numberTypes;
         std::unordered_map<std::string, std::string> _vars;
         std::unordered_map<std::string, std::string> _consts;
         std::unordered_set<std::string> _types;
+        std::unordered_map<std::string, std::vector<FunType>> _funs;
         std::shared_ptr<Scope> _parent;
     };
 

--- a/include/Vandior/Transpiler.hpp
+++ b/include/Vandior/Transpiler.hpp
@@ -16,7 +16,6 @@ namespace vnd {
         void transpile();
     private:
         Transpiler(std::vector<Instruction> _instructions) noexcept;
-        static bool canAssign(const std::string &left, const std::string &right) noexcept;
         int _tabs;
         std::string _text;
         std::ofstream _output;

--- a/input.vn
+++ b/input.vn
@@ -1,5 +1,5 @@
 const variable, variable2: bool = 1 == #f2 && 1 + 3 <= -6.57 + #o7 ^ 2 || false, true <= false
-const intVar: int = 2
+const intVar: int = 2 + testPar(test() ^ 7 / 6, 78.78)
 main {
 	var v1, v2: float = 1 + 2, 2 * 56 *(65 + 8.98 ^ 1 + testPar(6 / 7 + testPar(1, 3), 1 + 5) + (35 + 56 -67 / 7)) + 2 / intVar
 	const variable, variable2: char = 'c', 'V'

--- a/input.vn
+++ b/input.vn
@@ -1,9 +1,12 @@
 const variable, variable2: bool = 1 == #f2 && 1 + 3 <= -6.57 + #o7 ^ 2 || false, true <= false
 const intVar: int = 2 + testPar(test() ^ 7 / 6, 78.78)
 main {
-	var v1, v2: float = 1 + 2, 2 * 56 *(65 + 8.98 ^ 1 + testPar(6 / 7 + testPar(1, 3), 1 + 5) + (35 + 56 -67 / 7)) + 2 / intVar
+	var v1, v2: float = 1 + 2 + testPar(intVar, intVar), 2 * 56 *(65 + 8.98 ^ 1 + testPar(6 / 7 + testPar(1, 3), 1 + 5) + (35 + 56 -67 / 7)) + 2 / intVar
 	const variable, variable2: char = 'c', 'V'
-	var s, s2: string = "Ciao", "Text"
+	var s, s2: string = "Ciao"
+	var s3, s4: int = testPar(s), testPar("Text")
+	var pow, div: float = 1 ^ 2 ^ 3, 1 / 2 / 3
+	var powDiv, divPow: int = 1 ^ 2 / 3 ^ 4 / 5, 1 / 2 ^ 3 / 4 ^ 5 ^ 8.98 ^ 67
 	{
 	}
 }

--- a/input.vn
+++ b/input.vn
@@ -1,7 +1,7 @@
 const variable, variable2: bool = 1 == #f2 && 1 + 3 <= -6.57 + #o7 ^ 2 || false, true <= false
 const intVar: int = 2
 main {
-	var v1, v2: float = 1 + 2, 2 * 56 *(65 + 8.98 ^ (35 + 56 -67 / 7)) + 2 / intVar
+	var v1, v2: float = 1 + 2, 2 * 56 *(65 + 8.98 ^ 1 + testPar(6 / 7 + testPar(1, 3), 1 + 5) + (35 + 56 -67 / 7)) + 2 / intVar
 	const variable, variable2: char = 'c', 'V'
 	var s, s2: string = "Ciao", "Text"
 	{

--- a/src/Vandior_Lib/ExpressionFactory.cpp
+++ b/src/Vandior_Lib/ExpressionFactory.cpp
@@ -160,7 +160,11 @@ namespace vnd {
         _iterator++;
         while(_iterator->getType() != TokenType::CLOSE_PARENTESIS) {
             _iterator++;
-            if(std::string error = factory.parse({TokenType::COMMA, TokenType::CLOSE_PARENTESIS}); !error.empty()) { return error; }
+            if(_iterator->getType() != TokenType::CLOSE_PARENTESIS) {
+                if(std::string error = factory.parse({TokenType::COMMA, TokenType::CLOSE_PARENTESIS}); !error.empty()) {
+                    return error;
+                }
+            }
         }
         _iterator++;
         expressions = factory.getExpressions();
@@ -168,9 +172,11 @@ namespace vnd {
         if(newType == "") { return FORMAT("Function {} not found", identifier); }
         if(std::string error = ExpressionFactory::checkType(type, newType); error != "") { return error; }
         for(Expression expression : expressions) { text += expression.getText() + ","; }
-        text.erase(0, 1);
-        text.pop_back();
-        _text.emplace_back(" " + std::string{identifier} + "(" + text + ")");
+        if(expressions.size() > 0 && !text.empty()) {
+            if(text[0] == ' ') { text.erase(0, 1); }
+            text.pop_back();
+        }
+        _text.emplace_back(" _" + std::string{identifier} + "(" + text + ")");
         if(_lastOperator != '\0') {
             _text.emplace_back(")");
             _lastOperator = '\0';

--- a/src/Vandior_Lib/Scope.cpp
+++ b/src/Vandior_Lib/Scope.cpp
@@ -2,7 +2,10 @@
 
 namespace vnd {
 
-    Scope::Scope(std::shared_ptr<Scope> parent) noexcept : _vars({}), _consts({}), _parent(std::move(parent)) {}
+    // NOLINTNEXTLINE
+    std::vector<std::string> Scope::_numberTypes = {"int", "float"};
+
+    Scope::Scope(std::shared_ptr<Scope> parent) noexcept : _vars({}), _consts({}), _funs({}), _parent(std::move(parent)) {}
 
     std::shared_ptr<Scope> Scope::create(std::shared_ptr<Scope> parent) noexcept {
         return std::make_shared<Scope>(Scope(std::move(parent)));
@@ -16,7 +19,17 @@ namespace vnd {
         mainScope->addType("char");
         mainScope->addType("bool");
         mainScope->addType("string");
+        mainScope->addFun("test", std::make_tuple<std::string, std::vector<std::string>>("int", {}));
+        mainScope->addFun("testPar", std::make_tuple<std::string, std::vector<std::string>>("int", {"int", "int"}));
         return mainScope;
+    }
+
+    bool Scope::isNumber(const std::string &type) noexcept {
+        return std::ranges::find(Scope::_numberTypes, type) != Scope::_numberTypes.end();
+    }
+
+    bool Scope::canAssign(const std::string &left, const std::string &right) noexcept {
+        return (Scope::isNumber(left) && Scope::isNumber(right)) || left == right;
     }
 
     std::shared_ptr<Scope> Scope::getParent() const noexcept { return _parent; }
@@ -33,6 +46,12 @@ namespace vnd {
             return;
         }
         _vars[std::string{identifier}] = type;
+    }
+
+    void Scope::addFun(const std::string_view identifier, const FunType &fun) noexcept {
+        std::string key = std::string{identifier};
+        if(_funs.find(key) == _funs.end()) { _funs[key] = {}; }
+        _funs[key].emplace_back(fun);
     }
 
     bool Scope::isMainScope() const noexcept { return _parent == nullptr; }
@@ -56,6 +75,28 @@ namespace vnd {
         if(_vars.find(std::string{identifier}) != _vars.end()) { return _vars.at(std::string{identifier}); }
         if(_consts.find(std::string{identifier}) != _consts.end()) { return _consts.at(std::string{identifier}); }
         if(_parent) { return _parent->getVariableType(identifier); }
+        return "";
+    }
+
+    std::string Scope::getFunType(const std::string_view identifier, const std::vector<Expression> &expressions) const noexcept {  // NOLINT(*-no-recursion)
+        std::string_view result;
+        bool found;
+        if(_funs.find(std::string{identifier}) != _funs.end()) {
+            for(FunType fun : _funs.at(std::string{identifier})) {
+                found = true;
+                if(std::get<1>(fun).size() != expressions.size()) {
+                    found = false;
+                } else {
+                    for(size_t par = 0; par != std::get<1>(fun).size(); par++) {
+                        if(!Scope::canAssign(get<1>(fun).at(par), expressions.at(par).getType())) { found = false; }
+                    }
+                }
+                if(found) {
+                    return std::string{std::get<0>(fun)};
+                }
+            }
+        }
+        if(_parent) { return _parent->getFunType(identifier, expressions); }
         return "";
     }
 

--- a/src/Vandior_Lib/Scope.cpp
+++ b/src/Vandior_Lib/Scope.cpp
@@ -21,6 +21,7 @@ namespace vnd {
         mainScope->addType("string");
         mainScope->addFun("test", std::make_tuple<std::string, std::vector<std::string>>("int", {}));
         mainScope->addFun("testPar", std::make_tuple<std::string, std::vector<std::string>>("int", {"int", "int"}));
+        mainScope->addFun("testPar", std::make_tuple<std::string, std::vector<std::string>>("int", {"string"}));
         return mainScope;
     }
 

--- a/src/Vandior_Lib/Transpiler.cpp
+++ b/src/Vandior_Lib/Transpiler.cpp
@@ -14,8 +14,8 @@ namespace vnd {
         _text += "#include <cmath>\n";
         _text += "#include <vector>\n";
         _text += "using std::string;\n";
-        _text += "int test() {return 0;}\n";
-        _text += "int testPar(int a, int b) {return a + b;}\n";
+        _text += "int _test() {return 0;}\n";
+        _text += "int _testPar(int a, int b) {return a + b;}\n";
         try {
             for(const Instruction &instruction : _instructions) {
                 _text += std::string(C_ST(_tabs), '\t');

--- a/src/Vandior_Lib/Transpiler.cpp
+++ b/src/Vandior_Lib/Transpiler.cpp
@@ -6,10 +6,6 @@ namespace vnd {
 
     Transpiler Transpiler::create(std::vector<Instruction> instructions) noexcept { return {std::move(instructions)}; }
 
-    bool Transpiler::canAssign(const std::string &left, const std::string &right) noexcept {
-        return (ExpressionFactory::isNumber(left) && ExpressionFactory::isNumber(right)) || left == right;
-    }
-
     void Transpiler::transpile() {
         using enum TokenType;
         using enum InstructionType;
@@ -18,6 +14,8 @@ namespace vnd {
         _text += "#include <cmath>\n";
         _text += "#include <vector>\n";
         _text += "using std::string;\n";
+        _text += "int test() {return 0;}\n";
+        _text += "int testPar(int a, int b) {return a + b;}\n";
         try {
             for(const Instruction &instruction : _instructions) {
                 _text += std::string(C_ST(_tabs), '\t');
@@ -92,7 +90,6 @@ namespace vnd {
         while(iterator != tokens.end() && iterator->getType() != TokenType::EQUAL_OPERATOR) {
             if(iterator->getType() == TokenType::OPEN_SQ_PARENTESIS) {
                 type = std::string("std::vector<").append(type).append(">");
-                ;
             }
             iterator++;
         }
@@ -116,7 +113,7 @@ namespace vnd {
             _text += jvar;
             if(!factory.empty()) {
                 Expression expression = factory.getExpression();
-                if(!Transpiler::canAssign(type, expression.getType())) {
+                if(!Scope::canAssign(type, expression.getType())) {
                     throw TranspilerException(FORMAT("Cannot assign {} to {}", expression.getType(), type), instruction);
                 }
                 _text += " =";

--- a/src/Vandior_Lib/Transpiler.cpp
+++ b/src/Vandior_Lib/Transpiler.cpp
@@ -16,6 +16,7 @@ namespace vnd {
         _text += "using std::string;\n";
         _text += "int _test() {return 0;}\n";
         _text += "int _testPar(int a, int b) {return a + b;}\n";
+        _text += "int _testPar(string s) {return s.size();}\n";
         try {
             for(const Instruction &instruction : _instructions) {
                 _text += std::string(C_ST(_tabs), '\t');


### PR DESCRIPTION
I added the possibility to call functions.
The only available functions are int test() { return 0; }, int testPar(int a, int b) { return a + b; }, testPar(string s) { return s.size(); }, that are predefined inf the code, since it's impossible, for now, to define custom functions.
The fucntion overload is theorically possible, but the resolution alghoritm doesn't work property, since it select the first suitable functions for the given argument, not the one wich will be used in the effective C++ code.
As last thing, i refractored the transpiling of ^ and / operators because, in the previous commits, combinations of these two operators could lead to invalid C++ code.