### PR TITLE
Transpiler dev

### DIFF
--- a/base.hpp
+++ b/base.hpp
@@ -81,6 +81,9 @@ namespace vnd {
 				if(index < 0 || index >= static_cast<int64_t>(this->size())) { throw std::runtime_error("Index " + std::to_string(index) +  " out of bounds for size " + std::to_string(static_cast<int64_t>(this->size()))); }
 				return std::vector<T>::at(index);
 			}
+			void add(const T elem) {
+				std::vector<T>::emplace_back(elem);
+			}
 	};
 	std::unordered_map<std::string, std::any> tmp;
 }

--- a/base.hpp
+++ b/base.hpp
@@ -74,12 +74,22 @@ namespace vnd {
 				if(index < 0 || index >= static_cast<int64_t>(this->size())) { throw std::runtime_error("Index " + std::to_string(index) +  " out of bounds for size " + std::to_string(static_cast<int64_t>(this->size()))); }
 				return std::vector<T>::at(index);
 			}
-			const T& at(int64_t index) const {
+			const T at(int64_t index) const {
 				if(index < 0) {
 					index += static_cast<int64_t>(this->size());
 				}
 				if(index < 0 || index >= static_cast<int64_t>(this->size())) { throw std::runtime_error("Index " + std::to_string(index) +  " out of bounds for size " + std::to_string(static_cast<int64_t>(this->size()))); }
 				return std::vector<T>::at(index);
+			}
+			void addVector(const vnd::vector<T> elems) {
+				for(const T &i: elems) {
+					std::vector<T>::emplace_back(i);
+				}
+			}
+			void addAll(const vnd::vector<T> elems) {
+				for(const T &i: elems) {
+					std::vector<T>::emplace_back(i);
+				}
 			}
 			void add(const T elem) {
 				std::vector<T>::emplace_back(elem);

--- a/base.hpp
+++ b/base.hpp
@@ -25,6 +25,9 @@ class string: public std::string {
 			if(index < 0 || index >= size()) { throw std::runtime_error("Index " + std::to_string(index) +  " out of bounds for size " + std::to_string(size())); }
 			return std::string::at(index);
 		}
+		const int toInt() {
+			return std::stoi(*this);
+		}
 };
 
 namespace vnd {

--- a/examples/hello.vn
+++ b/examples/hello.vn
@@ -1,0 +1,5 @@
+main {
+	println("Hello World!") //Comment
+	/* Multi line
+	comment */
+}

--- a/examples/sum.vn
+++ b/examples/sum.vn
@@ -1,0 +1,9 @@
+main {
+	var num1, num2: int
+	print("Insert the first number:\t")
+	num1 = readLine().toInt()
+	print("Insert the second number:\t")
+	num2 = readLine().toInt()
+	val sum: int = num1 + num2
+	println("Sum:\t{}", sum)
+}

--- a/include/Vandior/FunType.hpp
+++ b/include/Vandior/FunType.hpp
@@ -12,11 +12,21 @@ namespace vnd {
          * @brief Creates a FunType instance.
          * @param returnType String containing return type. If the function has multiple return types, the are separated by a whitespace.
          * @param params Vector containing the types of the parameters. If it's a variadic function, the last type ends with "...".
+         * @param typeGeneric Vector of generic parameters of the class.
+         * @param funcGeneric Vector of generic parameters of the function.
          * @param constructor Bool flag that indicates if it's a constructor.
          * @return FunType instance.
          */
         [[nodiscard]] static FunType create(const std::string &returnType, const std::vector<std::string> &params,
+                                            const std::vector<std::pair<std::string, std::string>> &typeGeneric,
+                                            const std::vector<std::pair<std::string, std::string>> &funcGeneric,
                                             const bool constructor = false) noexcept;
+
+        /**
+         * @brief Creates an empty FunType instance
+         * @return an empty FunType instance.
+         */
+        [[nodiscard]] static FunType createEmpty() noexcept;
 
         /**
          * @brief Gets the return type of the function.
@@ -31,6 +41,18 @@ namespace vnd {
         [[nodiscard]] std::vector<std::string> getParams() const noexcept;
 
         /**
+         * @brief Gets the generic parameters of the class.
+         * @return vector containing the parameters.
+         */
+        [[nodiscard]] std::vector<std::pair<std::string, std::string>> getTypeGeneric() const noexcept;
+
+        /**
+         * @brief Gets the generic parameters of the function.
+         * @return vector containing the parameters.
+         */
+        [[nodiscard]] std::vector<std::pair<std::string, std::string>> getFuncGeneric() const noexcept;
+
+        /**
          * @brief Indicates if the function is a constructor,
          * @return the constructor flag.
          */
@@ -41,14 +63,20 @@ namespace vnd {
          * @brief Constructor of a FunType.
          * @param returnType String containing return type. If the function has multiple return types, the are separated by a whitespace.
          * @param params Vector containing the types of the parameters. If it's a variadic function, the last type ends with "...".
+         * @param typeGeneric Vector of generic parameters of the class.
+         * @param funcGeneric Vector of generic parameters of the function.
          * @param constructor Bool flag that indicates if it's a constructor.
          */
-        FunType(const std::string &returnType, const std::vector<std::string> &params, const bool constructor) noexcept
-          : _returnType(returnType), _params(params), _constructor(constructor) {}
+        FunType(const std::string &returnType,
+                const std::vector<std::string> &params, const std::vector<std::pair<std::string, std::string>> &typeGeneric,
+                const std::vector<std::pair<std::string, std::string>> &funcGeneric, const bool constructor) noexcept
+          : _returnType(returnType), _params(params), _typeGeneric(typeGeneric), _funcGeneric(funcGeneric), _constructor(constructor) {}
 
-        std::string _returnType;            ///< String of the return types separate by a whitespace.
-        std::vector<std::string> _params;   ///< Vector of type parameters.
-        bool _constructor;                  ///< Flag that indicates if the function is a constructor.
+        std::string _returnType;                                        ///< String of the return types separate by a whitespace.
+        std::vector<std::string> _params;                               ///< Vector of type parameters.
+        std::vector<std::pair<std::string, std::string>> _typeGeneric;  ///< Vector of generic types associated at the type.
+        std::vector<std::pair<std::string, std::string>> _funcGeneric;  ///< Vector of generic types associated at the function.
+        bool _constructor;                                              ///< Flag that indicates if the function is a constructor.
     };
 
 }  // namespace vnd

--- a/include/Vandior/Scope.hpp
+++ b/include/Vandior/Scope.hpp
@@ -157,24 +157,6 @@ namespace vnd {
         [[nodiscard]] std::string getConstValue(const std::string &type, const std::string_view &identifier) const noexcept;
 
         /**
-         * @brief gets the function corresponding to an identifier.
-         * @param type String representing the type containing the method. Is the function is not a method, the parameter is
-         * empty.
-         * @param identifier String_view representing the identifier of the function.
-         * @return Vector containing the found functions.
-         */
-        [[nodiscard]] std::vector<FunType> getFuns(const std::string &type, const std::string_view &identifier) const noexcept;
-
-        /**
-         * @brief Specializes the generic types of a funtion.
-         * @param fun FunType to specialize.
-         * @param typeSpecialized Vector of class specialized types.
-         * @return Pair of the specialized FunType and flag that indicates if the specialization succeeds.
-         */
-        [[nodiscard]] std::pair<FunType, bool> specializeFun(const FunType &fun,
-                                                             const std::vector<std::string> &typeSpecialized) const noexcept;
-
-        /**
          * @brief Checks if a variable is a constant.
          * @param type String representing the type containing the property. Is the variable is not a property, the parameter is
          * empty.
@@ -244,6 +226,15 @@ namespace vnd {
          */
         [[nodiscard]] static std::string getType(const std::string &type) noexcept;
 
+        /**
+         * @brief gets the type of a generic parameter.
+         * @param param String containing the parameter type.
+         * @param typeGeneric Vector of generic parameters of the type.
+         * @return String containing the parameter type. If the parameter is not generic, the result is the same of param.
+         */
+        [[nodiscard]] static std::string getParamType(const std::string &param,
+                                                      const std::vector<std::pair<std::string, std::string>> typeGeneric) noexcept;
+
         std::unordered_map<std::string, std::string> _vars;  ///< Map of variables identifiers and types.
         std::unordered_map<std::string, std::string> _vals;  ///< Map of constants identifiers and types.
         std::unordered_map<std::string, std::pair<std::string, std::string>>
@@ -253,6 +244,24 @@ namespace vnd {
         std::unordered_map<std::string, std::string> _tmp;                 ///< Map of temporary variables and types.
         std::shared_ptr<Scope> _parent;                                    ///< Shared pointer to the parent scope.
         ScopeType _type;
+
+        /**
+         * @brief gets the function corresponding to an identifier.
+         * @param type String representing the type containing the method. Is the function is not a method, the parameter is
+         * empty.
+         * @param identifier String_view representing the identifier of the function.
+         * @return Vector containing the found functions.
+         */
+        [[nodiscard]] std::vector<FunType> getFuns(const std::string &type, const std::string_view &identifier) const noexcept;
+
+        /**
+         * @brief Specializes the generic types of a funtion.
+         * @param fun FunType to specialize.
+         * @param typeSpecialized Vector of type specialized parameters.
+         * @return Pair of the specialized FunType and flag that indicates if the specialization succeeds.
+         */
+        [[nodiscard]] std::pair<FunType, bool> specializeFun(const FunType &fun,
+                                                             const std::vector<std::string> &typeSpecialized) const noexcept;
     };
 
 }  // namespace vnd

--- a/include/Vandior/Scope.hpp
+++ b/include/Vandior/Scope.hpp
@@ -181,24 +181,6 @@ namespace vnd {
          */
         [[nodiscard]] std::string addTmp(std::string key, std::string &type) noexcept;
 
-        /**
-         * @brief Gets a temporary variable from the tmp map.
-         * @param tmp String representing the identifier of the variable.
-         * @return String containing the value used in the C++ code to retrieve the value.
-         */
-        [[nodiscard]] std::string getTmp(const std::string &tmp) const noexcept;
-
-        /**
-         * @brief Exprecutes a function for each temporary variable.
-         * @param fun Function the execute.
-         */
-        void eachTmp(const std::function<void(const std::string &key)> &fun) const noexcept;
-
-        /**
-         * @brief Clears the tmp map.
-         */
-        void clearTmp() noexcept;
-
     private:
         /**
          * @brief Constructor of a Scope.
@@ -241,7 +223,6 @@ namespace vnd {
             _consts;  ///< Map of compile time constants identifiers and types.
         std::unordered_map<std::string, std::vector<std::string>> _types;  ///< Map of types and assignabled types.
         std::unordered_map<std::string, std::vector<FunType>> _funs;       ///< Map of function identifiers and informations.
-        std::unordered_map<std::string, std::string> _tmp;                 ///< Map of temporary variables and types.
         std::shared_ptr<Scope> _parent;                                    ///< Shared pointer to the parent scope.
         ScopeType _type;
 

--- a/include/Vandior/Scope.hpp
+++ b/include/Vandior/Scope.hpp
@@ -166,6 +166,15 @@ namespace vnd {
         [[nodiscard]] std::vector<FunType> getFuns(const std::string &type, const std::string_view &identifier) const noexcept;
 
         /**
+         * @brief Specializes the generic types of a funtion.
+         * @param fun FunType to specialize.
+         * @param typeSpecialized Vector of class specialized types.
+         * @return the specialized FunType.
+         */
+        [[nodiscard]] std::pair<FunType, bool> specializeFun(const FunType &fun,
+                                                             const std::vector<std::string> &typeSpecialized) const noexcept;
+
+        /**
          * @brief Checks if a variable is a constant.
          * @param type String representing the type containing the property. Is the variable is not a property, the parameter is
          * empty.

--- a/include/Vandior/Scope.hpp
+++ b/include/Vandior/Scope.hpp
@@ -61,7 +61,7 @@ namespace vnd {
         [[nodiscard]] std::shared_ptr<Scope> getParent() const noexcept;
 
         /**
-         * @Gets the scope type.
+         * @brief Gets the scope type.
          * @return ScopeType of the scope.
          */
         [[nodiscard]] ScopeType getType() const noexcept;
@@ -155,6 +155,15 @@ namespace vnd {
          * constant, the result is empty.
          */
         [[nodiscard]] std::string getConstValue(const std::string &type, const std::string_view &identifier) const noexcept;
+
+        /**
+         * @brief gets the function corresponding to an identifier.
+         * @param type String representing the type containing the method. Is the function is not a method, the parameter is
+         * empty.
+         * @param identifier String_view representing the identifier of the function.
+         * @return Vector containing the found functions.
+         */
+        [[nodiscard]] std::vector<FunType> getFuncs(const std::string &type, const std::string_view &identifier) const noexcept;
 
         /**
          * @brief Checks if a variable is a constant.

--- a/include/Vandior/Scope.hpp
+++ b/include/Vandior/Scope.hpp
@@ -163,7 +163,7 @@ namespace vnd {
          * @param identifier String_view representing the identifier of the function.
          * @return Vector containing the found functions.
          */
-        [[nodiscard]] std::vector<FunType> getFuncs(const std::string &type, const std::string_view &identifier) const noexcept;
+        [[nodiscard]] std::vector<FunType> getFuns(const std::string &type, const std::string_view &identifier) const noexcept;
 
         /**
          * @brief Checks if a variable is a constant.

--- a/include/Vandior/Transpiler.hpp
+++ b/include/Vandior/Transpiler.hpp
@@ -182,6 +182,9 @@ namespace vnd {
                                                                         const std::vector<TokenType> &endTokens,
                                                                         const Instruction &instruction);
 
+        [[nodiscard]] std::string transpileAssigment(const std::string &variable, const std::string &type,
+                                                     const Token &equalToken, const Expression &expression) noexcept;
+
         /**
          * @brief Transpile an if or while condition.
          * @param iterator The iterator pointing to the condition token sequence.

--- a/input.vn
+++ b/input.vn
@@ -1,8 +1,9 @@
 main {
-	var array1, array2: Object[] = {Object(), Object()}, {Derived(), Object()} 
+	var array1, array2: Object[2] = {Object(), Object()}, {Derived(), Object()} 
 	var array3, array4: Derived[] = {Derived(), Derived()} 
 	var num: int = 5
 	var num1: float = 45
+	println("{}", num1)
 	if(true) {
 		if(num == 2) {
 			println("2")
@@ -21,16 +22,16 @@ main {
 		while(false) {}
 	}
 	for num = num + 3 ^ 4, 100, 1 + 1 {
-		println("for 1:\t {}", num)
+		println("for 1:\t{}", num)
 	}
 	for var i: int = 45.43 ^ (num / num1), -100, -1 {
 		if(i < 0 && i > -50) {
 			continue
 		}
-		println("for 2:\t {}", i)
+		println("for 2:\t{}", i)
 	}
 	for var i: float = 0.4, 5.6 {
-		println("for 3:\t {}", i)
+		println("for 3:\t{}", i)
 	}
 	for num = 1, 10, 10 {}
 	for var j: float = 1, 10 {}

--- a/input.vn
+++ b/input.vn
@@ -1,12 +1,11 @@
 const nume : int = 334
 const dmnum : float = 1.222222222222
+const boolc: bool = 1 == 1 || !false && 67 < 77.85
 main {
-	var array1, array2: Object[2] = {Object(), Object()}, {Derived(), Object()} 
-	var array3, array4: Derived[] = {Derived(), Derived(), Derived()} 
-	var num: int = 45
-	println("{}", num)
+	var array1, array2: Object[] = {Object(), Object()}, {Derived(), Object()} 
+	var array3, array4: Derived[2] = {Derived(), Derived()} 
+	var num: int = 5
 	var num1: float = 45
-	print("{}", num1)
 	if(true) {
 		if(num == 2) {
 			println("2")
@@ -45,19 +44,6 @@ main {
 		}
 		println(s)
 	}
-	var intarray: int[] = {1, 2, 3}
-	var size: int = intarray.size()
-	println("Size:\t{}", size)
-	for var i: int = 0, size {
-		println("A\t{}", intarray[i])
-	}
-	intarray.add(-1)
-	intarray.addVector({1, 2})
-	intarray.addAll(1, -2)
-	intarray[0] = 1454
-	size = intarray.size()
-	println("Size:\t{}", size)
-	for var i: int = 0, intarray.size() {
-		println("A\t{}", intarray[i])
-	}
+	array1[0 ^ 1] = Object()
+	println("{}", array1[0 ^ 1].a)
 }

--- a/input.vn
+++ b/input.vn
@@ -43,5 +43,16 @@ main {
 		}
 		println(s)
 	}
-	
+	var intarray: int[] = {1, 2, 3}
+	var size: int = intarray.size()
+	println("Size:\t{}", size)
+	for var i: int = 0, size {
+		println("A\t{}", intarray[i])
+	}
+	intarray.add(-1)
+	size = intarray.size()
+	println("Size:\t{}", size)
+	for var i: int = 0, intarray.size() {
+		println("A\t{}", intarray[i])
+	}
 }

--- a/input.vn
+++ b/input.vn
@@ -50,6 +50,9 @@ main {
 		println("A\t{}", intarray[i])
 	}
 	intarray.add(-1)
+	intarray.addVector({1, 2})
+	intarray.addAll(1, -2)
+	intarray[0] = 1454
 	size = intarray.size()
 	println("Size:\t{}", size)
 	for var i: int = 0, intarray.size() {

--- a/input.vn
+++ b/input.vn
@@ -1,7 +1,8 @@
 main {
 	var array1, array2: Object[2] = {Object(), Object()}, {Derived(), Object()} 
-	var array3, array4: Derived[] = {Derived(), Derived()} 
-	var num: int = 5
+	var array3, array4: Derived[] = {Derived(), Derived(), Derived()} 
+	var num: int = array3.size()
+	println("{}", num)
 	var num1: float = 45
 	print("{}", num1)
 	if(true) {

--- a/input.vn
+++ b/input.vn
@@ -1,7 +1,7 @@
 main {
 	var array1, array2: Object[2] = {Object(), Object()}, {Derived(), Object()} 
 	var array3, array4: Derived[] = {Derived(), Derived(), Derived()} 
-	var num: int = array3.size()
+	var num: int = 45
 	println("{}", num)
 	var num1: float = 45
 	print("{}", num1)

--- a/src/Vandior_Lib/Expression.cpp
+++ b/src/Vandior_Lib/Expression.cpp
@@ -4,7 +4,8 @@ namespace vnd {
     // NOLINTBEGIN(*-include-cleaner, *-easily-swappable-parameters , *-pass-by-value)
     Expression::Expression(const std::string &text, const std::string &type, const bool isConst,
                            const std::string &value) noexcept
-      : _text(text), _type(type), _const(isConst), _value(value) {}
+      : _text(text), _type(type), _const(isConst), _value(value) {
+    }
 
     Expression Expression::create(const std::vector<std::string> &text, const std::string &type, const bool isConst,
                                   const std::string &value) noexcept {

--- a/src/Vandior_Lib/ExpressionFactory.cpp
+++ b/src/Vandior_Lib/ExpressionFactory.cpp
@@ -1,5 +1,4 @@
 #include "Vandior/ExpressionFactory.hpp"
-#include "Vandior/Log.hpp"
 #include <algorithm>
 
 // NOLINTBEGIN(*-include-cleaner, *-env33-c)
@@ -62,7 +61,7 @@ namespace vnd {
         std::array<char, buffer_size> buffer{};
         while(fgets(buffer.data(), buffer_size, pipe.get()) != nullptr) { sss << buffer.data(); }
         std::string result = sss.str();
-        LINFO("{}", result);
+        while(result.ends_with("\n")) { result.pop_back(); }
         return result;
     }
 

--- a/src/Vandior_Lib/ExpressionFactory.cpp
+++ b/src/Vandior_Lib/ExpressionFactory.cpp
@@ -211,7 +211,7 @@ namespace vnd {
             ++_iterator;
             return;
         }
-        auto text = _scope->getTmp(_temp + writeToken());
+        auto text = _temp + writeToken();
         if(_const) {
             if(_iterator->getType() == TokenType::IDENTIFIER) {
                 auto constValue = _scope->getConstValue(_type, _iterator->getValue());
@@ -480,7 +480,7 @@ namespace vnd {
     void ExpressionFactory::write(const std::string &value, const std::string_view &type) noexcept {
         clearData();
         if(checkNextToken(std::string{type}, value)) { return; }
-        std::string text = _scope->getTmp(_temp + value);
+        std::string text = _temp + value;
         checkOperators(text);
         _text.emplace_back(text);
         ++_iterator;

--- a/src/Vandior_Lib/ExpressionFactory.cpp
+++ b/src/Vandior_Lib/ExpressionFactory.cpp
@@ -37,12 +37,11 @@ namespace vnd {
         size_t pos = 0;
         std::ranges::for_each(expressions, [&](const Expression &expression) {
             if(variadic.has_value() && pos == variadic.value()) { params += "{"; }
-            params += expression.getText() + ",";
+            params += expression.getText() + ", ";
             pos++;
         });
         if(!params.empty()) {
-            if(params.at(0) == ' ') { params.erase(0, 1); }
-            params.pop_back();
+            params.erase(params.size() - 2, 2);
         }
         if(variadic.has_value()) {
             if(pos <= variadic.value()) { params += ", {"; }
@@ -67,7 +66,7 @@ namespace vnd {
         std::array<char, buffer_size> buffer{};
         while(fgets(buffer.data(), buffer_size, pipe.get()) != nullptr) { sss << buffer.data(); }
         std::string result = sss.str();
-        while(result.ends_with("\n")) { result.pop_back(); }
+        if(result.ends_with('\n')) { result.pop_back(); }
         return result;
     }
 
@@ -197,9 +196,8 @@ namespace vnd {
             ++_iterator;
             return;
         }
-        _text.emplace_back(" ");
         if(value == "^") {
-            if(!_power.has_value()) { _power = _text.size() - 2; }
+            if(!_power.has_value()) { _power = _text.size() - 1; }
             auto textIndex = _text.begin() + C_LL(_power.value());
             if(_sq) {
                 _text.emplace(textIndex, "int(std::pow(");
@@ -225,6 +223,7 @@ namespace vnd {
             }
         }
         checkOperators(text);
+        if(!_text.empty()) { text = FORMAT(" {}", text); }
         _text.emplace_back(text);
         if(value == "/" && !_sq) { _divide = true; }
         ++_iterator;
@@ -238,7 +237,7 @@ namespace vnd {
                 if(!value.empty() && value.at(0) == '_') {
                     value = FORMAT("v{}", value);
                 } else {
-                    value = FORMAT(" _{}", value);
+                    value = FORMAT("_{}", value);
                 }
             } else {
                 value = FORMAT("get{}{}()", char(std::toupper(value.at(0))), value.substr(1));
@@ -286,15 +285,14 @@ namespace vnd {
         }
         if(std::string error = ExpressionFactory::checkType(type, newType); !error.empty()) { return error; }
         params = ExpressionFactory::transpileFun(expressions, variadic);
-        std::string value = FORMAT(" {}({})", std::string{identifier}, params);
+        std::string value = FORMAT("{}({})", std::string{identifier}, params);
         if(_temp.empty()) {
-            value.erase(0, 1);
             if(constructor) {
                 value = FORMAT("std::make_shared<{}>({})", newType, params);
             } else if(!value.empty() && value.at(0) == '_') {
                 value = FORMAT("v{}", value);
             } else {
-                value = FORMAT(" _{}", value);
+                value = FORMAT("_{}", value);
             }
         }
         write(value, newType);
@@ -311,7 +309,7 @@ namespace vnd {
         if(auto newType = expression.getType(); newType != "int") { return FORMAT("{} index not allowed", newType); }
         if(auto error = ExpressionFactory::checkType(type, _type); !error.empty()) { return error; }
         _const = false;
-        write(FORMAT("at({})", expression.getText().substr(1)), _type);
+        write(FORMAT("at({})", expression.getText()), _type);
         return {};
     }
 
@@ -344,15 +342,14 @@ namespace vnd {
             // NOLINTEND(*-branch-clone)
             if(!assignable) { return FORMAT("Incompatible types in vector {}, {}", vectorType, expression.getType()); }
             if(expression.isConst()) {
-                constValue += FORMAT("{},", expression.getValue());
+                constValue += FORMAT("{}, ", expression.getValue());
             } else {
                 _const = false;
             }
-            value += FORMAT("{},", expression.getText());
+            value += FORMAT("{}, ", expression.getText());
         }
         if(!value.empty()) {
-            value.pop_back();
-            if(value.at(0) == ' ') { value.erase(0, 1); }
+            value.erase(value.size() - 2, 2);
         }
         vectorType += "[]";
         if(auto error = checkType(type, vectorType); !error.empty()) { return error; }
@@ -365,6 +362,7 @@ namespace vnd {
     }
 
     std::string ExpressionFactory::handleInnerExpression(TupType &type) noexcept {  // NOLINT(*-no-recursion)
+        std::string value;
         auto factory = ExpressionFactory::create(_iterator, _end, _scope, _const);
         ++_iterator;
         if(auto error = factory.parse({TokenType::CLOSE_PARENTESIS}); !error.empty()) { return error; }
@@ -377,7 +375,7 @@ namespace vnd {
         } else {
             _const = false;
         }
-        write(FORMAT(" ({})", expression.getText().substr(1)), newType);
+        write(FORMAT("({})", expression.getText()), newType);
         return {};
     }
 
@@ -473,8 +471,11 @@ namespace vnd {
         if(_power.has_value()) {
             value = FORMAT("{})", value);
             if(_sq) { value = FORMAT("{})", value); }
+            if((_iterator + 1) == _end || (_iterator + 1)->getValue() != "^") {
+                _text.emplace(_text.begin() + C_LL(_power.value()), " ");
+                _power.reset();
+            }
         }
-        if((_iterator + 1) == _end || (_iterator + 1)->getValue() != "^") { _power.reset(); }
     }
 
     void ExpressionFactory::write(const std::string &value, const std::string_view &type) noexcept {
@@ -482,6 +483,7 @@ namespace vnd {
         if(checkNextToken(std::string{type}, value)) { return; }
         std::string text = _temp + value;
         checkOperators(text);
+        if(!_text.empty()) { text = FORMAT(" {}", text); }
         _text.emplace_back(text);
         ++_iterator;
         _dot = false;

--- a/src/Vandior_Lib/FunType.cpp
+++ b/src/Vandior_Lib/FunType.cpp
@@ -3,13 +3,21 @@
 namespace vnd {
     // NOLINTNEXTLINE(*-include-cleaner)
     FunType FunType::create(const std::string &returnType, const std::vector<std::string> &params,
+                            const std::vector<std::pair<std::string, std::string>> &typeGeneric,
+                            const std::vector<std::pair<std::string, std::string>> &funcGeneric,
                             const bool constructor) noexcept {
-        return {returnType, params, constructor};
+        return {returnType, params, typeGeneric, funcGeneric, constructor};
     }
+
+    FunType FunType::createEmpty() noexcept { return {"", {}, {}, {}, false}; }
 
     std::string FunType::getReturnType() const noexcept { return _returnType; } // NOLINT(*-include-cleaner)
 
     std::vector<std::string> FunType::getParams() const noexcept { return _params; } // NOLINT(*-include-cleaner)
+
+    std::vector<std::pair<std::string, std::string>> FunType::getTypeGeneric() const noexcept { return _typeGeneric; }
+
+    std::vector<std::pair<std::string, std::string>> FunType::getFuncGeneric() const noexcept { return _funcGeneric; }
 
     bool FunType::isConstructor() const noexcept { return _constructor; }
 

--- a/src/Vandior_Lib/Scope.cpp
+++ b/src/Vandior_Lib/Scope.cpp
@@ -281,29 +281,6 @@ namespace vnd {
         return false;
     }
 
-    std::string Scope::addTmp(std::string key, std::string &type) noexcept {
-        if(key.ends_with("(")) {
-            key.replace(key.find_last_of('>') + 1, 1, "g");
-            key = FORMAT("{})", key);
-        }
-        std::erase(key, ' ');
-        _tmp.try_emplace(key, type);
-        return key;
-    }
-
-    std::string Scope::getTmp(const std::string &tmp) const noexcept {
-        auto key = tmp;
-        std::erase(key, ' ');
-        if(_tmp.contains(key)) { return FORMAT("std::any_cast<{}>(vnd::tmp.at(\"{}\"))", _tmp.at(key), key); }
-        return tmp;
-    }
-
-    void Scope::eachTmp(const std::function<void(const std::string &key)> &fun) const noexcept {
-        for(const auto &[key, value] : _tmp) { fun(key); }
-    }
-
-    void Scope::clearTmp() noexcept { _tmp.clear(); }
-
     std::vector<FunType> Scope::getFuns(const std::string &type, const std::string_view &identifier) const noexcept {
         std::vector<FunType> result;
         std::vector<std::string> typeSpecialized;

--- a/src/Vandior_Lib/Scope.cpp
+++ b/src/Vandior_Lib/Scope.cpp
@@ -61,6 +61,7 @@ namespace vnd {
         mainScope->addFun("vnd::vector.size", FunType::create("int", {}, {{"T", "any"}}, {}));
         mainScope->addFun("vnd::array.size", FunType::create("int", {}, {{"T", "any"}}, {}));
         mainScope->addFun("string.size", FunType::create("int", {}, {}, {}));
+        mainScope->addFun("string.toInt", FunType::create("int", {}, {}, {}));
         mainScope->addFun("Object.f", FunType::create("float", {"float"}, {}, {}));
         mainScope->addFun("Object.fs", FunType::create("string", {}, {}, {}));
         mainScope->addFun("Derived.derivedFun", FunType::create("bool", {"Object"}, {}, {}));

--- a/src/Vandior_Lib/Scope.cpp
+++ b/src/Vandior_Lib/Scope.cpp
@@ -298,7 +298,19 @@ namespace vnd {
                         continue;
                     }
                 }
-                for(const auto i : fun.second) { result.emplace_back(i); }
+                for(const auto i : fun.second) {
+                    std::vector<std::string> paramTypes;
+                    for(const auto &j : i.getParams()) {
+                        auto it = std::find_if(genericParams.begin(), genericParams.end(),
+                                               [&j](std::pair<std::string, std::string> element) { return j == element.first; });
+                        if(it == genericParams.end()) {
+                            paramTypes.emplace_back(j);
+                        } else {
+                            paramTypes.emplace_back(it->second);
+                        }
+                    }
+                    result.emplace_back(FunType::create(i.getReturnType(), paramTypes, i.isConstructor()));
+                }
             }
             //if(!identifier.contains('<') && current.second.contains('<')) {
             //    std::string genericIdentifier = type.substr(0, type.find('<'));

--- a/src/Vandior_Lib/Transpiler.cpp
+++ b/src/Vandior_Lib/Transpiler.cpp
@@ -524,7 +524,6 @@ namespace vnd {
             for(const auto &expression : expressions) { paramTypes += expression.getType() + ","; }
             if(!paramTypes.empty()) { paramTypes.pop_back(); }
             value = FORMAT("{}.{}({})", type, identifier, paramTypes);
-            LINFO(value);
             if(value.starts_with(".")) { value.erase(0, 1); }
             return FORMAT("Function {} not found", value);
         }
@@ -630,7 +629,7 @@ namespace vnd {
                     if(!expression.isConst()) {
                         throw TranspilerException("Cannot evaluate array dimension at compile time", instruction);
                     }
-                    size = expression.getValue().substr(0, expression.getValue().find('.'));
+                    size = expression.getValue();
                     if(std::stoi(size) < 0) { throw TranspilerException("Array cannot have negative size", instruction); }
                     prefix += "vnd::array<";
                     suffix = FORMAT(", {}>{}", size, suffix);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -853,14 +853,14 @@ TEST_CASE("Transpiler transpile operation instruction", "[transpiler]") {
     REQUIRE(code == "#include \"../../../../base.hpp\"\n\n"
                     "int main(int argc, char **argv) {\n"
                     "\tconst vnd::vector<string> _args(argv, argv + argc);\n"
-                    "\t_print(string(\"Test {}\"),{ _args.at(0)});\n"
+                    "\t_print(string(\"Test {}\"), {_args.at(0)});\n"
                     "\treturn 0;\n"
                     "}\n");
 #else
     REQUIRE(code == "#include \"../../../base.hpp\"\n\n"
                     "int main(int argc, char **argv) {\n"
                     "\tconst vnd::vector<string> _args(argv, argv + argc);\n"
-                    "\t_print(string(\"Test {}\"),{ _args.at(0)});\n"
+                    "\t_print(string(\"Test {}\"), {_args.at(0)});\n"
                     "\treturn 0;\n"
                     "}\n");
 #endif

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -870,9 +870,7 @@ TEST_CASE("Transpiler transpile assignation instruction", "[transpiler]") {
 int main(int argc, char **argv) {
 	const vnd::vector<string> _args(argv, argv + argc);
 	int _num{};
-	vnd::tmp["_num"] = _num;
-	_num =  1;
-	vnd::tmp.clear();
+	_num = 1;
 	return 0;
 }
 )");
@@ -882,9 +880,7 @@ int main(int argc, char **argv) {
 int main(int argc, char **argv) {
 	const vnd::vector<string> _args(argv, argv + argc);
 	int _num{};
-	vnd::tmp["_num"] = _num;
-	_num =  1;
-	vnd::tmp.clear();
+	_num = 1;
 	return 0;
 }
 )");


### PR DESCRIPTION
# Generics
The generic functions have been added. The only exsisting generic funtions are the vector add, addvector and addAll methods.
The generic parameters can depends by the type or by the function itselfs. For now, only the type parameters are handled. The function parameters are not handles since there is no generic function of that type. In any case, it's all set up to handle them.
# Removed tmp
The usage of tmp map in assignations has been removed, even if the map is stiil used for multiple return functions.
# Expression reftractoring
I reftratored Expression parsing so the external classes haven't to worry about the initial space that was present in the epression text.