### PR TITLE
Added warning

### DIFF
--- a/examples/complexSum.vn
+++ b/examples/complexSum.vn
@@ -1,0 +1,11 @@
+main {
+	var num1, num2: c32
+	print("Insert the first number:\t")
+	num1 = readLine().toC32()
+	println("{}", num1)
+	print("Insert the second number:\t")
+	num2 = readLine().toC32()
+	println("{}", num2)
+	val sum: c32 = num1 + num2
+	println("Sum:\t{}", sum)
+}

--- a/include/Vandior/Scope.hpp
+++ b/include/Vandior/Scope.hpp
@@ -180,9 +180,9 @@ namespace vnd {
          * @brief Checks if a a type can be assigned.
          * @param left String representing the type of the variable to be assigned.
          * @param right String representing the type of the expression to assign.
-         * @return Bool containing the result of the check.
+         * @return Pair containing the result of the check and a possible precision loss.
          */
-        [[nodiscard]] bool canAssign(const std::string &left, const std::string &right) const noexcept;
+        [[nodiscard]] std::pair<bool, bool> canAssign(const std::string &left, const std::string &right) const noexcept;
 
     private:
         /**

--- a/include/Vandior/Transpiler.hpp
+++ b/include/Vandior/Transpiler.hpp
@@ -55,6 +55,16 @@ namespace vnd {
         [[nodiscard]] static bool checkGlobalScope(const InstructionType &type) noexcept;
 
         /**
+         * @brief print a precision loss warning.
+         * @param instruction Current instrution.
+         * @param loss Bool flag indicating if there's precision loss.
+         * @param left String containing left type of assiggnation.
+         * @param right String containing right type of assiggnation.
+         */
+        void static printPrecisionLossWarning(const Instruction &instruction, bool loss, const std::string &left,
+                                              const std::string &right) noexcept;
+
+        /**
          * @brief Checks if there's a trailing bracket in the instruction.
          * @param instruction The instruction to check.
          */
@@ -198,9 +208,9 @@ namespace vnd {
          * @param type Type of the variable.
          * @param equalToken Token containing the equal operator informations.
          * @param expression Expression to assign.
-         * @return Parsed string if there is an error. If no error occurs, an empty string is returned.
+         * @return Pair of parsed error string and precision loss flag. If no error occurs, an empty string is returned.
          */
-        [[nodiscard]] std::string transpileAssigment(const std::string &variable, const std::string &type, const Token &equalToken,
+        [[nodiscard]] std::pair<std::string, bool> transpileAssigment(const std::string &variable, const std::string &type, const Token &equalToken,
                                                      const Expression &expression) noexcept;
 
         /**

--- a/include/Vandior/Transpiler.hpp
+++ b/include/Vandior/Transpiler.hpp
@@ -166,10 +166,10 @@ namespace vnd {
          * @brief transpile a multi return value function instruction.
          * @param variables Vector of identifiers and types of assigned variables.
          * @param expressiom Expression conataining the function.
-         * @return Parsed string if there is an error. If no error occurs, an empty string is returned.
+         * @return Pair of parsed error and warning strings. If no error occurs, an empty string is returned.
          */
-        [[nodiscard]] std::string transpileMultipleFun(const std::vector<std::pair<std::string, std::string>> &variables,
-                                                       const Expression &expression) noexcept;
+        [[nodiscard]] std::pair<std::string, std::string> transpileMultipleFun(const std::vector<std::pair<std::string, std::string>> &variables,
+                                                                               const Expression &expression) noexcept;
 
         /**
          * @brief Transpile a type name.

--- a/include/base.hpp
+++ b/include/base.hpp
@@ -222,12 +222,12 @@ string _readLine() {
 	std::getline (std::cin, input);
 	return string(input);
 }
-std::tuple<int, float> _max(vnd::vector<float>) {
+std::tuple<i64, f64> _max(vnd::vector<f64>) {
 	
 	return {0, 0};
 	
 }
-vnd::vector<int> _arrayTest() {
+vnd::vector<i32> _arrayTest() {
 	return {1, 2, 3};
 }
 std::shared_ptr<Object> _createObject() { return std::make_shared<Object>(); }

--- a/include/string.hpp
+++ b/include/string.hpp
@@ -27,14 +27,24 @@ class string {
 		const f32 toF32() {
 			return static_cast<f32>(std::stof(*str));
 		}
-		/*const c32 toC32() {
+		const c32 toC32() {
+			f32 real{}, imag{};
+			char sign = '+';
 			std::istringstream iss(*str);
-			float realPart, imaginaryPart;
-			if (iss >> realPart >> std::ws && iss.peek() == '+' && iss >> std::ws && iss >> imaginaryPart >> std::ws && iss.peek() == 'i') {
-				return c32(realPart, imaginaryPart);
+			size_t pos_i = str->find('i');
+			if (pos_i != std::string::npos) {
+				iss >> imag;
+				if (pos_i > 0) {
+					iss >> sign;
+					if (sign == '-') imag *= -1;
+					if (iss.peek() == 'i') iss.ignore();
+				}
 			}
-			return c32(0, 0);
-		}*/
+			if (iss >> real) {
+				if (sign == '-') imag *= -1;
+			}
+			return c32(real, imag);
+		}
 		std::string::const_iterator begin() const noexcept {
 			return str->begin();
 		}

--- a/input.vn
+++ b/input.vn
@@ -75,4 +75,8 @@ main {
 	var fnum: f64 = 20213412.32
 	fnum ^= 10 / 2 ^ 2 ^ 3.4
 	println("{}", fnum)
+	var maxI: i64
+	var maxF: f32
+	maxI, maxF = max({})
+	println("{} {}", maxI, maxF)
 }

--- a/input.vn
+++ b/input.vn
@@ -1,7 +1,10 @@
-const nume : i32 = 334
+const nume : u32 = 334
 const dmnum : f32 = 1.222222222222
 const boolc: bool = 1 == 1 || !false && 67 < 77.85
 main {
+	var warn1: f64 = 2
+	var warn2: f32 = warn1
+	warn2 = warn1
 	for var i: i32 = 0, args.size() {
 		println(args[i])
 	}

--- a/src/Vandior_Lib/ExpressionFactory.cpp
+++ b/src/Vandior_Lib/ExpressionFactory.cpp
@@ -359,13 +359,14 @@ namespace vnd {
         for(const auto &expression : factory.getExpressions()) {
             const auto &exprType = expression.getType();
             bool assignable = false;
+            std::pair<bool, bool> result;
             // NOLINTBEGIN(*-branch-clone)
             if(vectorType.empty()) {
                 vectorType = exprType;
                 assignable = true;
-            } else if(_scope->canAssign(vectorType, exprType)) {
+            } else if(result = _scope->canAssign(vectorType, exprType); result.first) {
                 assignable = true;
-            } else if(_scope->canAssign(exprType, vectorType)) {
+            } else if(result = _scope->canAssign(exprType, vectorType); result.first) {
                 vectorType = exprType;
                 assignable = true;
             }

--- a/src/Vandior_Lib/Scope.cpp
+++ b/src/Vandior_Lib/Scope.cpp
@@ -48,7 +48,7 @@ namespace vnd {
         mainScope->addFun("_test", FunType::create("i32", {}, {}, {}));
         mainScope->addFun("testPar", FunType::create("i32", {"i32", "i32"}, {}, {}));
         mainScope->addFun("testPar", FunType::create("i64", {"string"}, {}, {}));
-        mainScope->addFun("max", FunType::create("i32 f32", {"f32[]"}, {}, {}));
+        mainScope->addFun("max", FunType::create("i64 f64", {"f32[]"}, {}, {}));
         mainScope->addFun("arrayTest", FunType::create("i32[]", {}, {}, {}));
         mainScope->addFun("createObject", FunType::create("Object", {}, {}, {}));
         mainScope->addFun("Object", FunType::create("Object", {}, {}, {}, true));


### PR DESCRIPTION
I forbade to assign an integer value to a a variable of a smaller size of the same type. This is not valid for differen type, so it's possible to assign uxx to ixx in any case and vice versa. For floating point and complex numbers, instead, is possible to assign to a smaller precision but a warning is emitted,