### PR TITLE
Added operators

### DIFF
--- a/include/Vandior/parser/Parser.hpp
+++ b/include/Vandior/parser/Parser.hpp
@@ -16,6 +16,7 @@ namespace vnd {
         std::unique_ptr<ASTNode> parse();
 
     private:
+        static const std::vector<std::vector<std::string>> operatorPrecedence;
         void consumeToken() noexcept;
         // const Token &getNextToken();
         const Token &getCurrentToken() const;

--- a/src/Vandior_Lib/parser/Parser.cpp
+++ b/src/Vandior_Lib/parser/Parser.cpp
@@ -12,22 +12,30 @@ namespace vnd {
         if(position < tokenSize) { position++; }
     }
 
+    const std::vector<std::vector<std::string>> Parser::operatorPrecedence = {{"=", "+=", "-=", "*=", "/=", "^=", "%="},
+                                                                              {","},
+                                                                              {"||"},
+                                                                              {"&&"},
+                                                                              {"==", "!="},
+                                                                              {"<", "<=", ">", ">="},
+                                                                              {"+", "-"},
+                                                                              {"*", "/"},
+                                                                              {"^", "%"}};
+
     const Token &Parser::getCurrentToken() const { return tokens.at(position); }
     std::size_t Parser::getUnaryOperatorPrecedence(const Token &token) noexcept {
         const auto &tokenValue = token.getValue();
-        if(tokenValue == "+" || tokenValue == "-" || tokenValue == "!") { return 8; }
+        if(tokenValue == "+" || tokenValue == "-" || tokenValue == "!") { return operatorPrecedence.size() + 1; }
         return 0;
     }
 
     std::size_t Parser::getOperatorPrecedence(const Token &token) noexcept {
         const auto &tokenValue = token.getValue();
-        if(tokenValue == "||") { return 1; }
-        if(tokenValue == "&&") { return 2; }
-        if(tokenValue == "==" || tokenValue == "!=") { return 3; }
-        if(tokenValue == "<" || tokenValue == "<=" || tokenValue == ">" || tokenValue == ">=") { return 4; }
-        if(tokenValue == "+" || tokenValue == "-") { return 5; }
-        if(tokenValue == "*" || tokenValue == "/") { return 6; }
-        if(tokenValue == "^" || tokenValue == "%") { return 7; }
+        auto precedence = 0;
+        for(auto &i : operatorPrecedence) {
+            precedence++;
+            if(std::ranges::contains(i, tokenValue)) { return precedence; }
+        }
         return 0;
     }
     int Parser::convertToInt(std::string_view str) noexcept {

--- a/src/Vandior_Lib/parser/Parser.cpp
+++ b/src/Vandior_Lib/parser/Parser.cpp
@@ -20,12 +20,15 @@ namespace vnd {
                                                                               {"<", "<=", ">", ">="},
                                                                               {"+", "-"},
                                                                               {"*", "/"},
-                                                                              {"^", "%"}};
+                                                                              {"^", "%"},
+                                                                              {"."}};
 
     const Token &Parser::getCurrentToken() const { return tokens.at(position); }
     std::size_t Parser::getUnaryOperatorPrecedence(const Token &token) noexcept {
         const auto &tokenValue = token.getValue();
-        if(tokenValue == "+" || tokenValue == "-" || tokenValue == "!") { return operatorPrecedence.size() + 1; }
+        if(tokenValue == "+" || tokenValue == "-" || tokenValue == "!" || tokenValue == "++" || tokenValue == "--") {
+            return operatorPrecedence.size() + 1;
+        }
         return 0;
     }
 


### PR DESCRIPTION
I created a vector containing all binary operators ordered by the precedence. In ths way is possible to get the precedence of an operator with no need to hardcode the values in getBinaryOperatorPrecedence.
I also add other operators following the C++ precedence, with the only exception of the comma, to which I decided to assign a great precedence than = due the possibility in Vandior to make multi expression assignment, like:
```
a, b = 1, 2
```
In this case the root node of the AST should be the =, so it should have the lowest priority.