### PR TITLE
Added arrays

### DIFF
--- a/include/Vandior/parser/AST.hpp
+++ b/include/Vandior/parser/AST.hpp
@@ -57,6 +57,7 @@ static inline void prettyPrint(const vnd::ASTNode &node, const std::string &inde
         prettyPrint(*unaryNode->getOperand(), newindent, true, "OPERAND");
     } else if(const auto *variableNode = node.safe_as<vnd::VariableNode>()) {
         LINFO("{}(Type: VAR, val: {}){}", indentmark, variableNode->getName(), node.get_token().compat_to_string());
+        if(variableNode->get_index()) { prettyPrint(*variableNode->get_index(), newindent, true, "INDEX"); }
     } else if(const auto *intnumberNode = node.safe_as<vnd::NumberNode<int>>()) {
         LINFO("{}_{}, val: {}){}", imarknnum, NumNodeType_comp(intnumberNode->getNumberType()), intnumberNode->get_value(),
               node.get_token().compat_to_string());

--- a/include/Vandior/parser/AST.hpp
+++ b/include/Vandior/parser/AST.hpp
@@ -86,6 +86,10 @@ static inline void prettyPrint(const vnd::ASTNode &node, const std::string &inde
         LINFO("{}", indentmark, node.comp_print());
         if(indexNode->get_elements()) { prettyPrint(*indexNode->get_elements(), newindent, true, ""); }
         if(indexNode->get_index()) { prettyPrint(*indexNode->get_index(), newindent, true, "INDEX"); }
+        if(indexNode->get_array()) { prettyPrint(*indexNode->get_array(), newindent, true, "ELEM"); }
+    } else if(const auto *arrayNode = node.safe_as<vnd::ArrayNode>()) {
+        LINFO("{}", indentmark, node.comp_print());
+        if(arrayNode->get_elements()) { prettyPrint(*arrayNode->get_elements(), newindent, true, ""); }
     } else {
         LERROR("Unknown or not handled node type: {}", node.getType());
     }

--- a/include/Vandior/parser/AST.hpp
+++ b/include/Vandior/parser/AST.hpp
@@ -11,6 +11,7 @@
 #include "UnaryExpressionNode.hpp"
 #include "VariableNode.hpp"
 #include "TypeNode.hpp"
+#include "ArrayNode.hpp"
 
 /** \cond */
 DISABLE_WARNINGS_PUSH(
@@ -79,6 +80,9 @@ static inline void prettyPrint(const vnd::ASTNode &node, const std::string &inde
         LINFO("{}, val: {}){}", imarknode, svliteralNode->get_value(), node.get_token().compat_to_string());
     } else if(const auto *typeNode = node.safe_as<vnd::TypeNode>()) {
         LINFO("{}, type: {}){}", imarknode, typeNode->get_value(), node.get_token().compat_to_string());
+    } else if(const auto *intArratNode = node.safe_as<vnd::ArrayNode<int>>()) {
+        LINFO("{}, {}", imarknode, node.get_token().compat_to_string());
+        prettyPrint(*intArratNode->get_root(), newindent, true, "CHILD");
     } else {
         LERROR("Unknown or not handled node type: {}", node.getType());
     }

--- a/include/Vandior/parser/AST.hpp
+++ b/include/Vandior/parser/AST.hpp
@@ -80,9 +80,10 @@ static inline void prettyPrint(const vnd::ASTNode &node, const std::string &inde
         LINFO("{}, val: {}){}", imarknode, svliteralNode->get_value(), node.get_token().compat_to_string());
     } else if(const auto *typeNode = node.safe_as<vnd::TypeNode>()) {
         LINFO("{}, type: {}){}", imarknode, typeNode->get_value(), node.get_token().compat_to_string());
-    } else if(const auto *intArratNode = node.safe_as<vnd::ArrayNode<int>>()) {
+    } else if(const auto *intArratNode = node.safe_as<vnd::ArrayNode>()) {
         LINFO("{}, {}", imarknode, node.get_token().compat_to_string());
-        prettyPrint(*intArratNode->get_root(), newindent, true, "CHILD");
+        prettyPrint(*intArratNode->get_dimension(), newindent, true, "DIM");
+        prettyPrint(*intArratNode->get_elements(), newindent, true, "ELEM");
     } else {
         LERROR("Unknown or not handled node type: {}", node.getType());
     }

--- a/include/Vandior/parser/AST.hpp
+++ b/include/Vandior/parser/AST.hpp
@@ -11,7 +11,7 @@
 #include "UnaryExpressionNode.hpp"
 #include "VariableNode.hpp"
 #include "TypeNode.hpp"
-#include "ArrayNode.hpp"
+#include "IndexNode.hpp"
 
 /** \cond */
 DISABLE_WARNINGS_PUSH(
@@ -80,10 +80,10 @@ static inline void prettyPrint(const vnd::ASTNode &node, const std::string &inde
         LINFO("{}, val: {}){}", imarknode, svliteralNode->get_value(), node.get_token().compat_to_string());
     } else if(const auto *typeNode = node.safe_as<vnd::TypeNode>()) {
         LINFO("{}, type: {}){}", imarknode, typeNode->get_value(), node.get_token().compat_to_string());
-    } else if(const auto *intArratNode = node.safe_as<vnd::ArrayNode>()) {
-        LINFO("{}, {}", imarknode, node.get_token().compat_to_string());
-        prettyPrint(*intArratNode->get_dimension(), newindent, true, "DIM");
-        prettyPrint(*intArratNode->get_elements(), newindent, true, "ELEM");
+        if(typeNode->get_index()) { prettyPrint(*typeNode->get_index(), newindent, true, "INDEX"); }
+    } else if(const auto *indexNode = node.safe_as<vnd::IndexNode>()) {
+        LINFO("{}", indentmark, node.comp_print());
+        if(indexNode->get_elements()) { prettyPrint(*indexNode->get_elements(), newindent, true, ""); }
     } else {
         LERROR("Unknown or not handled node type: {}", node.getType());
     }

--- a/include/Vandior/parser/AST.hpp
+++ b/include/Vandior/parser/AST.hpp
@@ -84,6 +84,7 @@ static inline void prettyPrint(const vnd::ASTNode &node, const std::string &inde
     } else if(const auto *indexNode = node.safe_as<vnd::IndexNode>()) {
         LINFO("{}", indentmark, node.comp_print());
         if(indexNode->get_elements()) { prettyPrint(*indexNode->get_elements(), newindent, true, ""); }
+        if(indexNode->get_index()) { prettyPrint(*indexNode->get_index(), newindent, true, "INDEX"); }
     } else {
         LERROR("Unknown or not handled node type: {}", node.getType());
     }

--- a/include/Vandior/parser/ArrayNode.hpp
+++ b/include/Vandior/parser/ArrayNode.hpp
@@ -1,0 +1,64 @@
+//
+// Created by potex02 on 23/06/2024.
+//
+
+#pragma once
+
+#include "ASTNode.hpp"
+
+namespace vnd {
+
+    /**
+     * @brief Generic Node class representing literal array values in the AST.
+     * @tparam T The type of the literal array values.
+     */
+    template <typename T> class ArrayNode : public ASTNode {
+    public:
+        /**
+         * @brief Constructs a ArrayNode.
+         * @param root The root element of the array.
+         * @param token The token correspondent to the node.
+         */
+        [[nodiscard]] ArrayNode(std::unique_ptr<ASTNode> root, const Token &token) noexcept
+          : ASTNode(token), m_root(vnd_move_always_even_const(root)) {}
+
+        /**
+         * @brief Gets the type of the AST node.
+         * @return NodeType enumeration value.
+         */
+        [[nodiscard]] NodeType getType() const noexcept override { return NodeType::Array; }
+
+        /**
+         * @brief Returns a string representation of the AST node.
+         * @return String representation of the AST node.
+         */
+        [[nodiscard]] std::string print() const override { return FORMAT("arr"); }
+
+        /**
+         * @brief Returns a compact string representation of the AST node for compilation purposes.
+         * @return Compact string representation of the AST node.
+         */
+        [[nodiscard]] std::string comp_print() const override { return FORMAT("array"); }
+
+        /**
+         * @brief Gets the root of the node.
+         * @return The root of the node.
+         */
+        [[nodiscard]] const std::unique_ptr<ASTNode> &get_root() const noexcept { return m_root; }
+
+        /**
+         * @brief Swaps the contents of two LiteralNode objects.
+         * @param lhs The first LiteralNode.
+         * @param rhs The second LiteralNode.
+         */
+        friend void swap(ArrayNode &lhs, ArrayNode &rhs) noexcept {
+            using std::swap;
+            swap(static_cast<ASTNode &>(lhs), static_cast<ASTNode &>(rhs));
+            swap(lhs.m_root, rhs.m_root);
+        }
+
+    private:
+        std::unique_ptr<ASTNode> m_root;  ///< The root child of the array.
+    };
+
+}  // namespace vnd

--- a/include/Vandior/parser/ArrayNode.hpp
+++ b/include/Vandior/parser/ArrayNode.hpp
@@ -27,18 +27,24 @@ namespace vnd {
          * @return NodeType enumeration value.
          */
         [[nodiscard]] NodeType getType() const noexcept override { return NodeType::Array; }
+        
+        /**
+         * @brief Gets the demangled name of the type T.
+         * @return Demangled name of the type T if using GCC/Clang, otherwise mangled name.
+         */
+        [[nodiscard]] std::string_view getTypeIDName() const noexcept { return typeid(T).name(); }
 
         /**
          * @brief Returns a string representation of the AST node.
          * @return String representation of the AST node.
          */
-        [[nodiscard]] std::string print() const override { return FORMAT("arr"); }
+        [[nodiscard]] std::string print() const override { return FORMAT("{}<{}>", getType(), getTypeIDName()); }
 
         /**
          * @brief Returns a compact string representation of the AST node for compilation purposes.
          * @return Compact string representation of the AST node.
          */
-        [[nodiscard]] std::string comp_print() const override { return FORMAT("array"); }
+        [[nodiscard]] std::string comp_print() const override { return FORMAT("{}", getType()); }
 
         /**
          * @brief Gets the root of the node.

--- a/include/Vandior/parser/ArrayNode.hpp
+++ b/include/Vandior/parser/ArrayNode.hpp
@@ -1,0 +1,66 @@
+//
+// Created by potex02 on 10/07/2024.
+//
+
+#pragma once
+
+#include "ASTNode.hpp"
+
+namespace vnd {
+
+    /**
+     * @brief Node class representing literal array values in the AST.
+     * @tparam T The type of the literal array values.
+     */
+    class ArrayNode : public ASTNode {
+    public:
+        /**
+         * @brief Constructs a ArrayNode.
+         * @param root The root element of the array.
+         * @param token The token correspondent to the node.
+         */
+        [[nodiscard]] ArrayNode(std::unique_ptr<ASTNode> elements, const Token &token) noexcept
+          : ASTNode(token), m_elements(vnd_move_always_even_const(elements)) {}
+
+        /**
+         * @brief Gets the type of the AST node.
+         * @return NodeType enumeration value.
+         */
+        [[nodiscard]] NodeType getType() const noexcept override { return NodeType::Array; }
+
+        /**
+         * @brief Returns a string representation of the AST node.
+         * @return String representation of the AST node.
+         */
+        [[nodiscard]] std::string print() const override { return FORMAT("{}({})", getType(), m_elements->comp_print()); }
+        
+        /**
+         * @brief Returns a compact string representation of the AST node for compilation purposes.
+         * @return Compact string representation of the AST node.
+         */
+        [[nodiscard]] std::string comp_print() const override {
+            return FORMAT("{}", getType());
+        }
+
+        /**
+         * @brief Gets the elements of the node.
+         * @return The elements of the node.
+         */
+        [[nodiscard]] const std::unique_ptr<ASTNode> &get_elements() const noexcept { return m_elements; }
+
+        /**
+         * @brief Swaps the contents of two LiteralNode objects.
+         * @param lhs The first LiteralNode.
+         * @param rhs The second LiteralNode.
+         */
+        friend void swap(ArrayNode &lhs, ArrayNode &rhs) noexcept {
+            using std::swap;
+            swap(static_cast<ASTNode &>(lhs), static_cast<ASTNode &>(rhs));
+            swap(lhs.m_elements, rhs.m_elements);
+        }
+
+    private:
+        std::unique_ptr<ASTNode> m_elements;   ///< The elements child of the array.
+    };
+
+}  // namespace vnd

--- a/include/Vandior/parser/ArrayNode.hpp
+++ b/include/Vandior/parser/ArrayNode.hpp
@@ -12,45 +12,47 @@ namespace vnd {
      * @brief Generic Node class representing literal array values in the AST.
      * @tparam T The type of the literal array values.
      */
-    template <typename T> class ArrayNode : public ASTNode {
+    class ArrayNode : public ASTNode {
     public:
         /**
          * @brief Constructs a ArrayNode.
          * @param root The root element of the array.
          * @param token The token correspondent to the node.
          */
-        [[nodiscard]] ArrayNode(std::unique_ptr<ASTNode> root, const Token &token) noexcept
-          : ASTNode(token), m_root(vnd_move_always_even_const(root)) {}
+        [[nodiscard]] ArrayNode(std::unique_ptr<ASTNode> dimension, std::unique_ptr<ASTNode> elements, const Token &token) noexcept
+          : ASTNode(token), m_dimension(vnd_move_always_even_const(dimension)), m_elements(vnd_move_always_even_const(elements)) {}
 
         /**
          * @brief Gets the type of the AST node.
          * @return NodeType enumeration value.
          */
         [[nodiscard]] NodeType getType() const noexcept override { return NodeType::Array; }
-        
-        /**
-         * @brief Gets the demangled name of the type T.
-         * @return Demangled name of the type T if using GCC/Clang, otherwise mangled name.
-         */
-        [[nodiscard]] std::string_view getTypeIDName() const noexcept { return typeid(T).name(); }
 
         /**
          * @brief Returns a string representation of the AST node.
          * @return String representation of the AST node.
          */
-        [[nodiscard]] std::string print() const override { return FORMAT("{}<{}>", getType(), getTypeIDName()); }
+        [[nodiscard]] std::string print() const override { return FORMAT("{}<{}>", getType(), m_dimension->comp_print()); }
 
         /**
          * @brief Returns a compact string representation of the AST node for compilation purposes.
          * @return Compact string representation of the AST node.
          */
-        [[nodiscard]] std::string comp_print() const override { return FORMAT("{}", getType()); }
+        [[nodiscard]] std::string comp_print() const override {
+            return FORMAT("{}<{}>{}", getType(), m_dimension->comp_print(), m_elements->comp_print());
+        }
 
         /**
-         * @brief Gets the root of the node.
-         * @return The root of the node.
+         * @brief Gets the dimension of the node.
+         * @return The dimension of the node.
          */
-        [[nodiscard]] const std::unique_ptr<ASTNode> &get_root() const noexcept { return m_root; }
+        [[nodiscard]] const std::unique_ptr<ASTNode> &get_dimension() const noexcept { return m_dimension; }
+
+        /**
+         * @brief Gets the elements of the node.
+         * @return The elements of the node.
+         */
+        [[nodiscard]] const std::unique_ptr<ASTNode> &get_elements() const noexcept { return m_elements; }
 
         /**
          * @brief Swaps the contents of two LiteralNode objects.
@@ -60,11 +62,13 @@ namespace vnd {
         friend void swap(ArrayNode &lhs, ArrayNode &rhs) noexcept {
             using std::swap;
             swap(static_cast<ASTNode &>(lhs), static_cast<ASTNode &>(rhs));
-            swap(lhs.m_root, rhs.m_root);
+            swap(lhs.m_dimension, rhs.m_dimension);
+            swap(lhs.m_elements, rhs.m_elements);
         }
 
     private:
-        std::unique_ptr<ASTNode> m_root;  ///< The root child of the array.
+        std::unique_ptr<ASTNode> m_dimension;  ///< The dimension of the array.
+        std::unique_ptr<ASTNode> m_elements;   ///< The elements child of the array.
     };
 
 }  // namespace vnd

--- a/include/Vandior/parser/IndexNode.hpp
+++ b/include/Vandior/parser/IndexNode.hpp
@@ -73,7 +73,7 @@ namespace vnd {
 
     private:
         std::unique_ptr<ASTNode> m_elements;   ///< The elements child of the array.
-        std::unique_ptr<IndexNode> m_index;   ///< The possible index node of an array type.
+        std::unique_ptr<IndexNode> m_index;    ///< The possible index node of an array type.
     };
 
 }  // namespace vnd

--- a/include/Vandior/parser/IndexNode.hpp
+++ b/include/Vandior/parser/IndexNode.hpp
@@ -20,7 +20,7 @@ namespace vnd {
          * @param token The token correspondent to the node.
          */
         [[nodiscard]] IndexNode(std::unique_ptr<ASTNode> elements, const Token &token) noexcept
-          : ASTNode(token), m_elements(vnd_move_always_even_const(elements)) {}
+          : ASTNode(token), m_elements(vnd_move_always_even_const(elements)), m_index(nullptr) {}
 
         /**
          * @brief Gets the type of the AST node.
@@ -48,11 +48,17 @@ namespace vnd {
          */
         [[nodiscard]] const std::unique_ptr<ASTNode> &get_elements() const noexcept { return m_elements; }
 
-        /**
+         /**
          * @brief Gets the index node of the node.
-         * @return The index of the node.
+         * @return The index node of the node.
          */
-        //[[nodiscard]] const std::unique_ptr<IndexNode> &get_index() const noexcept { return m_index; }
+        [[nodiscard]] const std::unique_ptr<IndexNode> &get_index() const noexcept { return m_index; }
+
+        /**
+         * @brief Sets the index node of the node.
+         * @param index The index node of the node.
+         */
+        [[nodiscard]] void set_index(std::unique_ptr<IndexNode> index) noexcept { m_index = vnd_move_always_even_const(index); }
 
         /**
          * @brief Swaps the contents of two LiteralNode objects.
@@ -62,13 +68,12 @@ namespace vnd {
         friend void swap(IndexNode &lhs, IndexNode &rhs) noexcept {
             using std::swap;
             swap(static_cast<ASTNode &>(lhs), static_cast<ASTNode &>(rhs));
-            swap(lhs.m_dimension, rhs.m_dimension);
             swap(lhs.m_elements, rhs.m_elements);
         }
 
     private:
-        std::unique_ptr<ASTNode> m_dimension;  ///< The dimension of the array.
         std::unique_ptr<ASTNode> m_elements;   ///< The elements child of the array.
+        std::unique_ptr<IndexNode> m_index;   ///< The possible index node of an array type.
     };
 
 }  // namespace vnd

--- a/include/Vandior/parser/IndexNode.hpp
+++ b/include/Vandior/parser/IndexNode.hpp
@@ -5,22 +5,23 @@
 #pragma once
 
 #include "ASTNode.hpp"
+#include "ArrayNode.hpp"
 
 namespace vnd {
 
     /**
-     * @brief Generic Node class representing literal array values in the AST.
+     * @brief Node class representing an index values in the AST.
      * @tparam T The type of the literal array values.
      */
     class IndexNode : public ASTNode {
     public:
         /**
-         * @brief Constructs a ArrayNode.
-         * @param root The root element of the array.
+         * @brief Constructs a IndexNode.
+         * @param root The root element of the index.
          * @param token The token correspondent to the node.
          */
         [[nodiscard]] IndexNode(std::unique_ptr<ASTNode> elements, const Token &token) noexcept
-          : ASTNode(token), m_elements(vnd_move_always_even_const(elements)), m_index(nullptr) {}
+          : ASTNode(token), m_elements(vnd_move_always_even_const(elements)), m_index(nullptr), m_array(nullptr) {}
 
         /**
          * @brief Gets the type of the AST node.
@@ -61,6 +62,18 @@ namespace vnd {
         [[nodiscard]] void set_index(std::unique_ptr<IndexNode> index) noexcept { m_index = vnd_move_always_even_const(index); }
 
         /**
+         * @brief Gets the array node of the node.
+         * @return The array node of the node.
+         */
+        [[nodiscard]] const std::unique_ptr<ArrayNode> &get_array() const noexcept { return m_array; }
+
+        /**
+         * @brief Sets the array node of the node.
+         * @param index The array node of the node.
+         */
+        [[nodiscard]] void set_array(std::unique_ptr<ArrayNode> _array) noexcept { m_array = vnd_move_always_even_const(_array); }
+
+        /**
          * @brief Swaps the contents of two LiteralNode objects.
          * @param lhs The first LiteralNode.
          * @param rhs The second LiteralNode.
@@ -69,11 +82,14 @@ namespace vnd {
             using std::swap;
             swap(static_cast<ASTNode &>(lhs), static_cast<ASTNode &>(rhs));
             swap(lhs.m_elements, rhs.m_elements);
+            swap(lhs.m_index, rhs.m_index);
+            swap(lhs.m_array, rhs.m_array);
         }
 
     private:
-        std::unique_ptr<ASTNode> m_elements;   ///< The elements child of the array.
+        std::unique_ptr<ASTNode> m_elements;   ///< The elements child of the index.
         std::unique_ptr<IndexNode> m_index;    ///< The possible index node of an array type.
+        std::unique_ptr<ArrayNode> m_array;    ///< The array elements of the index.
     };
 
 }  // namespace vnd

--- a/include/Vandior/parser/IndexNode.hpp
+++ b/include/Vandior/parser/IndexNode.hpp
@@ -1,5 +1,5 @@
 //
-// Created by potex02 on 23/06/2024.
+// Created by potex02 on 06/07/2024.
 //
 
 #pragma once
@@ -12,41 +12,35 @@ namespace vnd {
      * @brief Generic Node class representing literal array values in the AST.
      * @tparam T The type of the literal array values.
      */
-    class ArrayNode : public ASTNode {
+    class IndexNode : public ASTNode {
     public:
         /**
          * @brief Constructs a ArrayNode.
          * @param root The root element of the array.
          * @param token The token correspondent to the node.
          */
-        [[nodiscard]] ArrayNode(std::unique_ptr<ASTNode> dimension, std::unique_ptr<ASTNode> elements, const Token &token) noexcept
-          : ASTNode(token), m_dimension(vnd_move_always_even_const(dimension)), m_elements(vnd_move_always_even_const(elements)) {}
+        [[nodiscard]] IndexNode(std::unique_ptr<ASTNode> elements, const Token &token) noexcept
+          : ASTNode(token), m_elements(vnd_move_always_even_const(elements)) {}
 
         /**
          * @brief Gets the type of the AST node.
          * @return NodeType enumeration value.
          */
-        [[nodiscard]] NodeType getType() const noexcept override { return NodeType::Array; }
+        [[nodiscard]] NodeType getType() const noexcept override { return NodeType::Index; }
 
         /**
          * @brief Returns a string representation of the AST node.
          * @return String representation of the AST node.
          */
-        [[nodiscard]] std::string print() const override { return FORMAT("{}<{}>", getType(), m_dimension->comp_print()); }
-
+        [[nodiscard]] std::string print() const override { return FORMAT("{}({})", getType(), m_elements->comp_print()); }
+        
         /**
          * @brief Returns a compact string representation of the AST node for compilation purposes.
          * @return Compact string representation of the AST node.
          */
         [[nodiscard]] std::string comp_print() const override {
-            return FORMAT("{}<{}>{}", getType(), m_dimension->comp_print(), m_elements->comp_print());
+            return FORMAT("{}", getType());
         }
-
-        /**
-         * @brief Gets the dimension of the node.
-         * @return The dimension of the node.
-         */
-        [[nodiscard]] const std::unique_ptr<ASTNode> &get_dimension() const noexcept { return m_dimension; }
 
         /**
          * @brief Gets the elements of the node.
@@ -55,11 +49,17 @@ namespace vnd {
         [[nodiscard]] const std::unique_ptr<ASTNode> &get_elements() const noexcept { return m_elements; }
 
         /**
+         * @brief Gets the index node of the node.
+         * @return The index of the node.
+         */
+        //[[nodiscard]] const std::unique_ptr<IndexNode> &get_index() const noexcept { return m_index; }
+
+        /**
          * @brief Swaps the contents of two LiteralNode objects.
          * @param lhs The first LiteralNode.
          * @param rhs The second LiteralNode.
          */
-        friend void swap(ArrayNode &lhs, ArrayNode &rhs) noexcept {
+        friend void swap(IndexNode &lhs, IndexNode &rhs) noexcept {
             using std::swap;
             swap(static_cast<ASTNode &>(lhs), static_cast<ASTNode &>(rhs));
             swap(lhs.m_dimension, rhs.m_dimension);

--- a/include/Vandior/parser/NodeType.hpp
+++ b/include/Vandior/parser/NodeType.hpp
@@ -7,7 +7,7 @@
 /**
  * @brief Enum representing different types of AST nodes.
  */
-enum class NodeType { BinaryExpression, UnaryExpression, Number, Boolean, Char, String, Variable, Type, Array };
+enum class NodeType { BinaryExpression, UnaryExpression, Number, Boolean, Char, String, Variable, Type, Index };
 
 /**
  * This function is a formatter for NodeType using fmt.
@@ -51,8 +51,8 @@ template <> struct fmt::formatter<NodeType> : fmt::formatter<std::string_view> {
         case Type:
             name = "TYPE";
             break;
-        case Array:
-            name = "ARRAY";
+        case Index:
+            name = "INDEX";
             break;
         default:
             name = "UNKOWN";

--- a/include/Vandior/parser/NodeType.hpp
+++ b/include/Vandior/parser/NodeType.hpp
@@ -7,7 +7,7 @@
 /**
  * @brief Enum representing different types of AST nodes.
  */
-enum class NodeType { BinaryExpression, UnaryExpression, Number, Boolean, Char, String, Variable, Type, Index };
+enum class NodeType { BinaryExpression, UnaryExpression, Number, Boolean, Char, String, Variable, Type, Index, Array };
 
 /**
  * This function is a formatter for NodeType using fmt.
@@ -53,6 +53,9 @@ template <> struct fmt::formatter<NodeType> : fmt::formatter<std::string_view> {
             break;
         case Index:
             name = "INDEX";
+            break;
+        case Array:
+            name = "ARRAY";
             break;
         default:
             name = "UNKOWN";

--- a/include/Vandior/parser/NodeType.hpp
+++ b/include/Vandior/parser/NodeType.hpp
@@ -7,7 +7,7 @@
 /**
  * @brief Enum representing different types of AST nodes.
  */
-enum class NodeType { BinaryExpression, UnaryExpression, Number, Boolean, Char, String, Variable, Type };
+enum class NodeType { BinaryExpression, UnaryExpression, Number, Boolean, Char, String, Variable, Type, Array };
 
 /**
  * This function is a formatter for NodeType using fmt.
@@ -50,6 +50,9 @@ template <> struct fmt::formatter<NodeType> : fmt::formatter<std::string_view> {
             break;
         case Type:
             name = "TYPE";
+            break;
+        case Array:
+            name = "ARRAY";
             break;
         default:
             name = "UNKOWN";

--- a/include/Vandior/parser/Parser.hpp
+++ b/include/Vandior/parser/Parser.hpp
@@ -32,7 +32,8 @@ namespace vnd {
         std::unique_ptr<ASTNode> parseUnary(std::size_t parentPrecendence);
         std::unique_ptr<ASTNode> parseBinary(std::size_t parentPrecendence);
         std::unique_ptr<ASTNode> parseExpression(std::size_t parentPrecendence = 0);
-        template <typename T> void parseIndex(std::unique_ptr<T> &node, bool isType = true);
+        template <typename T> void parseIndex(std::unique_ptr<T> &node);
+        bool parseArray(std::unique_ptr<IndexNode> &node);
 
         Tokenizer tokenizer;
         std::vector<Token> tokens{};

--- a/include/Vandior/parser/Parser.hpp
+++ b/include/Vandior/parser/Parser.hpp
@@ -33,6 +33,7 @@ namespace vnd {
         std::unique_ptr<ASTNode> parseBinary(std::size_t parentPrecendence);
         std::unique_ptr<ASTNode> parseExpression(std::size_t parentPrecendence = 0);
         [[nodiscard]] bool canBeType() const noexcept;
+        template <typename T> void parseIndex(std::unique_ptr<T> &node, bool isType = true);
 
         Tokenizer tokenizer;
         std::vector<Token> tokens{};

--- a/include/Vandior/parser/Parser.hpp
+++ b/include/Vandior/parser/Parser.hpp
@@ -32,7 +32,7 @@ namespace vnd {
         std::unique_ptr<ASTNode> parseUnary(std::size_t parentPrecendence);
         std::unique_ptr<ASTNode> parseBinary(std::size_t parentPrecendence);
         std::unique_ptr<ASTNode> parseExpression(std::size_t parentPrecendence = 0);
-        [[nodiscard]] bool isPreviusColon() const noexcept;
+        [[nodiscard]] bool canBeType() const noexcept;
 
         Tokenizer tokenizer;
         std::vector<Token> tokens{};

--- a/include/Vandior/parser/Parser.hpp
+++ b/include/Vandior/parser/Parser.hpp
@@ -32,7 +32,6 @@ namespace vnd {
         std::unique_ptr<ASTNode> parseUnary(std::size_t parentPrecendence);
         std::unique_ptr<ASTNode> parseBinary(std::size_t parentPrecendence);
         std::unique_ptr<ASTNode> parseExpression(std::size_t parentPrecendence = 0);
-        [[nodiscard]] bool canBeType() const noexcept;
         template <typename T> void parseIndex(std::unique_ptr<T> &node, bool isType = true);
 
         Tokenizer tokenizer;

--- a/include/Vandior/parser/TypeNode.hpp
+++ b/include/Vandior/parser/TypeNode.hpp
@@ -3,7 +3,8 @@
 //
 
 #pragma once
-#include "ASTNode.hpp"
+
+#include "IndexNode.hpp"
 
 namespace vnd {
 
@@ -16,7 +17,7 @@ namespace vnd {
          * @brief Creates a TypeNode.
          * @param token The token correspondent to the node.
          */
-        [[nodiscard]] explicit TypeNode(const Token &token) noexcept : ASTNode(token), m_value(token.getValue()), m_type(token.getType()) {}
+        [[nodiscard]] explicit TypeNode(const Token &token) noexcept : ASTNode(token), m_value(token.getValue()), m_type(token.getType()), m_index(nullptr) {}
 
         /**
          * @brief Gets the type of the AST node.
@@ -43,6 +44,18 @@ namespace vnd {
         [[nodiscard]] std::string_view get_value() const noexcept { return m_value; }
 
         /**
+         * @brief Gets the index node of the node.
+         * @return The index node of the node.
+         */
+        [[nodiscard]] const std::unique_ptr<IndexNode> &get_index() const noexcept { return m_index; }
+
+        /**
+         * @brief Sets the index node of the node.
+         * @param index The index node of the node.
+         */
+        [[nodiscard]] void set_index(std::unique_ptr<IndexNode> index) noexcept { m_index = vnd_move_always_even_const(index); }
+
+        /**
          * @brief Gets the variable type of the node.
          * @return The variable type of the node.
          */
@@ -56,8 +69,9 @@ namespace vnd {
         }
 
     private:
-        std::string_view m_value;  ///< The value of the node.
-        TokenType m_type;          ///< The type of the token node.
+        std::string_view m_value;             ///< The value of the node.
+        TokenType m_type;                     ///< The type of the token node.
+        std::unique_ptr<IndexNode> m_index;   ///< The possible index node of an array type.
     };
 
 }  // namespace vnd

--- a/include/Vandior/parser/TypeNode.hpp
+++ b/include/Vandior/parser/TypeNode.hpp
@@ -66,6 +66,7 @@ namespace vnd {
             swap(static_cast<ASTNode &>(lhs), static_cast<ASTNode &>(rhs));
             swap(lhs.m_value, rhs.m_value);
             swap(lhs.m_type, rhs.m_type);
+            swap(lhs.m_index, rhs.m_index);
         }
 
     private:

--- a/include/Vandior/parser/VariableNode.hpp
+++ b/include/Vandior/parser/VariableNode.hpp
@@ -45,6 +45,7 @@ namespace vnd {
             using std::swap;
             swap(static_cast<ASTNode &>(lhs), static_cast<ASTNode &>(rhs));
             swap(lhs.name, rhs.name);
+            swap(lhs.m_index, rhs.m_index);
         }
 
     private:

--- a/include/Vandior/parser/VariableNode.hpp
+++ b/include/Vandior/parser/VariableNode.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 #include "ASTNode.hpp"
+#include "IndexNode.hpp"
 
 DISABLE_WARNINGS_PUSH(26445)
 
@@ -19,13 +20,26 @@ namespace vnd {
          * @param _name Name of the variable.
          * @param name_Token token of the name of the variable.
          */
-        explicit VariableNode(std::string_view _name, const Token &name_Token) noexcept : ASTNode(name_Token), name(_name) {}
+        explicit VariableNode(std::string_view _name, const Token &name_Token) noexcept : ASTNode(name_Token), name(_name), m_index(nullptr) {}
 
         [[nodiscard]] NodeType getType() const noexcept override { return NodeType::Variable; }
 
         [[nodiscard]] std::string print() const override { return FORMAT("{}({})", getType(), name); }
         [[nodiscard]] std::string comp_print() const override { return FORMAT("VAR({})", name); }
         [[nodiscard]] const std::string_view &getName() const noexcept { return name; }
+
+        
+        /**
+         * @brief Gets the index node of the node.
+         * @return The index node of the node.
+         */
+        [[nodiscard]] const std::unique_ptr<IndexNode> &get_index() const noexcept { return m_index; }
+
+        /**
+         * @brief Sets the index node of the node.
+         * @param index The index node of the node.
+         */
+        [[nodiscard]] void set_index(std::unique_ptr<IndexNode> index) noexcept { m_index = vnd_move_always_even_const(index); }
 
         friend void swap(VariableNode &lhs, VariableNode &rhs) noexcept {
             using std::swap;
@@ -35,6 +49,7 @@ namespace vnd {
 
     private:
         std::string_view name;
+        std::unique_ptr<IndexNode> m_index;  ///< The possible index node of an array type.
     };
 
 }  // namespace vnd

--- a/src/Vandior_Lib/CMakeLists.txt
+++ b/src/Vandior_Lib/CMakeLists.txt
@@ -12,7 +12,7 @@ add_library(vandior_lib vandior.cpp
         parser/NumberNode.cpp
         parser/VariableNode.cpp
         parser/TypeNode.cpp
-        parser/ArrayNode.cpp
+        parser/IndexNode.cpp
 )
 
 add_library(Vandior::vandior_lib ALIAS vandior_lib)

--- a/src/Vandior_Lib/CMakeLists.txt
+++ b/src/Vandior_Lib/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(vandior_lib vandior.cpp
         parser/VariableNode.cpp
         parser/TypeNode.cpp
         parser/IndexNode.cpp
+        parser/ArrayNode.cpp
 )
 
 add_library(Vandior::vandior_lib ALIAS vandior_lib)

--- a/src/Vandior_Lib/CMakeLists.txt
+++ b/src/Vandior_Lib/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(vandior_lib vandior.cpp
         parser/NumberNode.cpp
         parser/VariableNode.cpp
         parser/TypeNode.cpp
+        parser/ArrayNode.cpp
 )
 
 add_library(Vandior::vandior_lib ALIAS vandior_lib)

--- a/src/Vandior_Lib/parser/ArrayNode.cpp
+++ b/src/Vandior_Lib/parser/ArrayNode.cpp
@@ -1,0 +1,9 @@
+//
+// Created by potex02 on 10/07/2024.
+//
+// NOLINTBEGIN(*-include-cleaner)
+#include "Vandior/parser/ArrayNode.hpp"
+
+namespace vnd {
+}  // namespace vnd
+   // NOLINTEND(*-include-cleaner)

--- a/src/Vandior_Lib/parser/ArrayNode.cpp
+++ b/src/Vandior_Lib/parser/ArrayNode.cpp
@@ -1,0 +1,9 @@
+//
+// Created by potex02 on 23/06/2024.
+//
+// NOLINTBEGIN(*-include-cleaner)
+#include "Vandior/parser/ArrayNode.hpp"
+
+namespace vnd {
+}  // namespace vnd
+   // NOLINTEND(*-include-cleaner)

--- a/src/Vandior_Lib/parser/IndexNode.cpp
+++ b/src/Vandior_Lib/parser/IndexNode.cpp
@@ -1,8 +1,8 @@
 //
-// Created by potex02 on 23/06/2024.
+// Created by potex02 on 06/07/2024.
 //
 // NOLINTBEGIN(*-include-cleaner)
-#include "Vandior/parser/ArrayNode.hpp"
+#include "Vandior/parser/IndexNode.hpp"
 
 namespace vnd {
 }  // namespace vnd

--- a/src/Vandior_Lib/parser/Parser.cpp
+++ b/src/Vandior_Lib/parser/Parser.cpp
@@ -185,6 +185,16 @@ namespace vnd {
                 // Handle error: mismatched parentheses
                 throw ParserException(currentToken);
             }
+        } else if(currentToken.getValue() == "{") {
+            consumeToken();
+            auto expression = parseExpression();
+            if(getCurrentToken().getValue() == "}") {
+                consumeToken();
+                return MAKE_UNIQUE(ArrayNode<int>, std::move(expression), currentToken);
+            } else {
+                // Handle error: mismatched parentheses
+                throw ParserException(currentToken);
+            }
         } else [[unlikely]] {
             // Handle error: unexpected token
             throw ParserException(currentToken);

--- a/src/Vandior_Lib/parser/Parser.cpp
+++ b/src/Vandior_Lib/parser/Parser.cpp
@@ -134,7 +134,7 @@ namespace vnd {
         const auto &currentValue = currentToken.getValue();
         auto cval = std::string{currentValue};
 
-        if(isPreviusColon()) {
+        if(canBeType()) {
             if(std::ranges::find(types, currentType) == types.end()) { throw ParserException(currentToken); }
             consumeToken();
             return MAKE_UNIQUE(TypeNode, currentToken);
@@ -236,7 +236,11 @@ namespace vnd {
 
     std::unique_ptr<ASTNode> Parser::parseExpression(std::size_t parentPrecendence) { return parseBinary(parentPrecendence); }
 
-    bool Parser::isPreviusColon() const noexcept { return position > 0 && tokens.at(position - 1).getType() == TokenType::COLON; }
+    bool Parser::canBeType() const noexcept {
+        if(position == 0) { return false; }
+        auto type = tokens.at(position - 1).getType();
+        return type == TokenType::COLON || type == TokenType::OPEN_SQ_PARENTESIS;
+    }
 }  // namespace vnd
 DISABLE_WARNINGS_POP()
 // NOLINTEND(*-include-cleaner,*-no-recursion, *-avoid-magic-numbers,*-magic-numbers)

--- a/src/Vandior_Lib/parser/Parser.cpp
+++ b/src/Vandior_Lib/parser/Parser.cpp
@@ -181,20 +181,29 @@ namespace vnd {
             if(getCurrentToken().getValue() == ")") {
                 consumeToken();
                 return expression;
-            } else {
+            }
+            // Handle error: mismatched parentheses
+            throw ParserException(currentToken);
+        } else if(currentToken.getValue() == "[") {
+            consumeToken();
+            auto dimension = parseExpression();
+            if(getCurrentToken().getValue() != "]") {
                 // Handle error: mismatched parentheses
                 throw ParserException(currentToken);
             }
-        } else if(currentToken.getValue() == "{") {
             consumeToken();
-            auto expression = parseExpression();
+            if(getCurrentToken().getValue() != "{") {
+                // Handle error: mismatched parentheses
+                throw ParserException(currentToken);
+            }
+            consumeToken();
+            auto elements = parseExpression();
             if(getCurrentToken().getValue() == "}") {
                 consumeToken();
-                return MAKE_UNIQUE(ArrayNode<int>, std::move(expression), currentToken);
-            } else {
-                // Handle error: mismatched parentheses
-                throw ParserException(currentToken);
+                return MAKE_UNIQUE(ArrayNode, std::move(dimension), std::move(elements), currentToken);
             }
+            // Handle error: mismatched parentheses
+            throw ParserException(currentToken);
         } else [[unlikely]] {
             // Handle error: unexpected token
             throw ParserException(currentToken);

--- a/src/Vandior_Lib/parser/Parser.cpp
+++ b/src/Vandior_Lib/parser/Parser.cpp
@@ -230,15 +230,17 @@ namespace vnd {
         consumeToken();
         if(getCurrentToken().getType() == TokenType::CLOSE_SQ_PARENTESIS) {
             consumeToken();
-            node->set_index(MAKE_UNIQUE(IndexNode, nullptr, token));
-            parseIndex<T>(node, isType);
+            auto index = MAKE_UNIQUE(IndexNode, nullptr, token);
+            parseIndex<IndexNode>(index, isType);
+            node->set_index(vnd_move_always_even_const(index));
             return;
         }
         auto elements = parseExpression();
         if(getCurrentToken().getType() != TokenType::CLOSE_SQ_PARENTESIS) { throw ParserException(getCurrentToken()); }
         consumeToken();
-        node->set_index(MAKE_UNIQUE(IndexNode, std::move(elements), token));
-        parseIndex<T>(node, isType);
+        auto index = MAKE_UNIQUE(IndexNode, std::move(elements), token);
+        parseIndex<IndexNode>(index, isType);
+        node->set_index(vnd_move_always_even_const(index));
     }
 
 }  // namespace vnd

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1538,39 +1538,58 @@ TEST_CASE("Parser emit exception for nonexistent unary operator", "[parser]") {
 }
 
 TEST_CASE("Parser emit i8 TypeNode node", "[parser]") {
-    vnd::Parser parser("a: i8", filename);
+    vnd::Parser parser("i8", filename);
     auto ast = parser.parse();
     REQUIRE(ast != nullptr);
-    REQUIRE(ast->getType() == NodeType::BinaryExpression);
-    const auto *binaryNode = ast->as<vnd::BinaryExpressionNode>();
-    REQUIRE(binaryNode != nullptr);
-    REQUIRE(binaryNode->getOp() == ":");
-    const auto *typeNode = binaryNode->getRight()->as<vnd::TypeNode>();
+    REQUIRE(ast->getType() == NodeType::Type);
+    const auto *typeNode = ast->as<vnd::TypeNode>();
     REQUIRE(typeNode != nullptr);
-    REQUIRE(typeNode->getType() == NodeType::Type);
     REQUIRE(typeNode->comp_print() == "TYPE(i8)");
     REQUIRE(typeNode->print() == "TYPE_I8_TYPE(i8)");
     REQUIRE(typeNode->getVariableType() == vnd::TokenType::TYPE_I8);
     REQUIRE(typeNode->get_value() == "i8");
+    REQUIRE(typeNode->get_index() == nullptr);
 }
 
-TEST_CASE("Parser emit identifier TypeNode node", "[parser]") {
-    vnd::Parser parser("a: type", filename);
+TEST_CASE("Parser emit array", "[parser]") {
+    vnd::Parser parser("i8[size][]{1, 2}", filename);
     auto ast = parser.parse();
     REQUIRE(ast != nullptr);
-    REQUIRE(ast->getType() == NodeType::BinaryExpression);
-    const auto *binaryNode = ast->as<vnd::BinaryExpressionNode>();
-    REQUIRE(binaryNode != nullptr);
-    REQUIRE(binaryNode->getOp() == ":");
-    const auto *typeNode = binaryNode->getRight()->as<vnd::TypeNode>();
+    REQUIRE(ast->getType() == NodeType::Type);
+    const auto *typeNode = ast->as<vnd::TypeNode>();
     REQUIRE(typeNode != nullptr);
-    REQUIRE(typeNode->getVariableType() == vnd::TokenType::IDENTIFIER);
-    REQUIRE(typeNode->get_value() == "type");
+    REQUIRE(typeNode->get_index() != nullptr);
+    REQUIRE(typeNode->get_index()->getType() == NodeType::Index);
+    REQUIRE(typeNode->get_index()->get_elements() != nullptr);
+    REQUIRE(typeNode->get_index()->get_index() != nullptr);
+    REQUIRE(typeNode->get_index()->get_array() == nullptr);
+    REQUIRE(typeNode->get_index()->get_index()->get_elements() == nullptr);
+    REQUIRE(typeNode->get_index()->get_index()->get_index() == nullptr);
+    REQUIRE(typeNode->get_index()->get_index()->get_array() != nullptr);
+    REQUIRE(typeNode->get_index()->get_index()->get_array()->getType() == NodeType::Array);
+    REQUIRE(typeNode->get_index()->get_index()->get_array()->get_elements() != nullptr);
 }
 
-TEST_CASE("Parser emit exception for impossibile TypeNode node", "[parser]") {
-    vnd::Parser parser("a: 1", filename);
+TEST_CASE("Parser emit empty array", "[parser]") {
+    vnd::Parser parser("Object[]{}", filename);
+    auto ast = parser.parse();
+    REQUIRE(ast != nullptr);
+    REQUIRE(ast->getType() == NodeType::Variable);
+    const auto *variable = ast->as<vnd::VariableNode>();
+    REQUIRE(variable != nullptr);
+    REQUIRE(variable->get_index() != nullptr);
+    REQUIRE(variable->get_index()->get_array() != nullptr);
+    REQUIRE(variable->get_index()->get_array()->getType() == NodeType::Array);
+    REQUIRE(variable->get_index()->get_array()->get_elements() == nullptr);
+}
+
+TEST_CASE("Parser emit mismatched square brackets exception", "[parser]") {
+    vnd::Parser parser("Object[size", filename);
     REQUIRE_THROWS_AS(parser.parse(), vnd::ParserException);
 }
 
+TEST_CASE("Parser emit mismatched curly brackets exception", "[parser]") {
+    vnd::Parser parser("string[size]{", filename);
+    REQUIRE_THROWS_AS(parser.parse(), vnd::ParserException);
+}
 // NOLINTEND(*-include-cleaner, *-avoid-magic-numbers, *-magic-numbers)


### PR DESCRIPTION
# Arrays
I added the arrays to to AST. This is done by adding a possibly nullptr IndexNode field to TypeNode and VariableNode. An IndexNode contains recursively another IndexNode, allowing multidimensional arrays. The IndexNode contains also an ASTNode pointer holding the nodes of the array size and an ArrayNode pointer containing the elements of the array. If the array has a variable size, the size pointer is set to nullptr.
## Fixed size array
```
arr = i8[5]{1, 2, 3, 4, 5}
```
## Variable size array:
```
arr = i8[]{1, 2, 3, 4, 5}
```
# Removed Type constraint
I removed the isColon (after renamed canBeType) method because the assertion that a type can be present only after a colon is no longer valid. I also deleted the Indentifier TokenType from the vnd::Parser::types, because removing the isColon method made impossible to check if an identifier is a class or a variable.
# Proposal for the next pull request
At the moment, the only way to create a multdimensional array is to recursively specify the type of each subarray:
```
arr = i8[2][]{i8[]{1, 2}, i8[]{3, 4, 5}}
```
My goal for the next pull request is to simplify this syntax allowing to avoid to specify the type of the subarrays:
```
arr = i8[2][]{{1, 2}, {3, 4, 5}}
```
Thid change would require to check if the array definitions is inside of another array definition, otherwise a syntax error should be thrown:
```
arr = {1, 2, 3, 4, 5} // This should throw a syntax error
```
My proposal is to avoid the checks and allow the above syntax, treating non-typed arrays as variable size array of any type:
```
arr = {1, 2, 3, 4, 5} // This would be treaten as arr = []any{1, 2, 3, 4, 5}
```